### PR TITLE
Add a development version of Hammer that supports D_s**

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,8 @@
             hammer-phys-w_root_6_24
             hammer-phys-w_root_6_16
             hammer-phys-w_root_6_12
+            # hammer dev
+            hammer-phys-dev
             # roounfold
             roounfold
             roounfold-w_root_6_24

--- a/nix/hammer-phys-dev/cymove_to_cython.patch
+++ b/nix/hammer-phys-dev/cymove_to_cython.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6e46fa16..dc9f70c9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -213,19 +213,6 @@ if(WITH_PYTHON)
+ 			include(FindCython)
+ 		endif()
+ 	endif()
+-	if(WITH_PYTHON)
+-		#check for cymove
+-		find_cython_module(cymove)
+-		if(NOT Python3_cymove_FOUND)
+-			if(Python3_pip_FOUND)
+-				install_python_module(cymove "1.0.0")
+-			endif()
+-			if(NOT Python3_cymove_INSTALLED)
+-				message (WARNING "cymove not found/installed. Hammer will only be accessible as a C++ library.")
+-				set(WITH_PYTHON OFF CACHE BOOL "" FORCE)
+-			endif()
+-		endif()
+-	endif()
+ 	if(WITH_PYTHON)
+ 		#check for numpy
+ 		if(CMAKE_VERSION VERSION_LESS "3.12.0")
+diff --git a/pyext/wrapper/hammerlib.pyx b/pyext/wrapper/hammerlib.pyx
+index e31737ad..f6567697 100644
+--- a/pyext/wrapper/hammerlib.pyx
++++ b/pyext/wrapper/hammerlib.pyx
+@@ -49,7 +49,7 @@ from libcpp.set cimport set as cset
+ from cython.operator import dereference as deref, preincrement as inc
+ from cpython cimport bool
+ 
+-from cymove cimport cymove as move
++from libcpp.utility cimport move
+ from cpython.version cimport PY_MAJOR_VERSION
+ 
+ import cmath

--- a/nix/hammer-phys-dev/default.nix
+++ b/nix/hammer-phys-dev/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitLab {
     owner = "mpapucci";
     repo = "Hammer";
-    rev = "development";
+    rev = "7474702d";
     sha256 = "6MBhkYTZ1gWqWFgfYqfFGF/AHZYhtCF38BgNI6dWYr4=";
   };
 

--- a/nix/hammer-phys-dev/default.nix
+++ b/nix/hammer-phys-dev/default.nix
@@ -1,0 +1,54 @@
+{ stdenv
+, lib
+, cmake
+, pkgconfig
+, boost
+, libyamlcpp
+, root
+, python3
+, fetchFromGitLab
+, enablePython ? false  # Python support requires a LD_LIBRARY_PATH export
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hammer-phys-dev";
+  version = "20230402";
+
+  src = fetchFromGitLab {
+    owner = "mpapucci";
+    repo = "Hammer";
+    rev = "development";
+    sha256 = "6MBhkYTZ1gWqWFgfYqfFGF/AHZYhtCF38BgNI6dWYr4=";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ]
+    ++ lib.optionals (enablePython) (with python3.pkgs; [ setuptools cython ])
+  ;
+
+  buildInputs = [ root ]
+    ++ lib.optionals (enablePython) (with python3.pkgs; [ numpy matplotlib ])
+  ;
+
+  propagatedBuildInputs = [ boost libyamlcpp ];
+
+  patches = [ ./cymove_to_cython.patch ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DWITH_ROOT=ON"
+    "-DINSTALL_EXTERNAL_DEPENDENCIES=OFF"
+  ]
+  ++ (if enablePython then [ "-DWITH_PYTHON=ON" ] else [ "-DWITH_PYTHON=OFF" ])
+  ;
+
+  # Move the .so files to the lib folder so the output looks like this:
+  #   lib/*.so
+  # instead of:
+  #   lib/Hammer/*.so
+  postFixup = ''
+    mv $out/lib/Hammer/* $out/lib
+    rm -rf $out/lib/Hammer
+  '';
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -43,6 +43,7 @@ final: prev:
     noSplash = true;
   };
   hammer-phys = prev.callPackage ./hammer-phys { };
+  hammer-phys-dev = prev.callPackage ./hammer-phys-dev { };
   roounfold = prev.callPackage ./roounfold { };
   roounfold_1_1 = prev.callPackage ./roounfold_1_1 { };
 


### PR DESCRIPTION
I added the latest `development` branch of `Hammer` which added support for `D_s**` FFs. The package **builds** successfully locally but of course I don't have time to test whether it works or not.

Now, you need to propagate the changes in `root-curated` in 2 of our projects:

- First in `hammer-reweight` to test if it actually works
- Once you have an updated reweighter, propagate both `root-curated` and `hammer-reweight` to `lhcb-ntuples-gen`

To do that, just do

```console
# in hammer-reweight
nix flake lock --update-input root-curated

# once you validate that this version of Hammer is working
# in lhcb-ntuples-gen
nix flake lock --update-input root-curated
nix flake lock --update-input hammer-reweight  # the hammer reweighter is integrated into our main ntuple building project via the flake mechanism
```

FYI @manuelfs @afernez 