### PR TITLE
Build ROOT with ImplicitMT and FFTW3; Add custom RooPowerLaw PDF; Extend TH3::Interpolate().

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.vscode-cpptools
 result

--- a/nix/root/default.nix
+++ b/nix/root/default.nix
@@ -59,6 +59,8 @@ stdenv.mkDerivation rec {
     ++ lib.optionals (automaticSIMD) [ vdt ]
   ;
 
+  enableParallelBuilding = true;
+
   patches = [
     ./sw_vers.patch
     ./hist_factory.patch

--- a/nix/root/default.nix
+++ b/nix/root/default.nix
@@ -33,6 +33,7 @@
 , nlohmann_json
 , tbb
 , vdt
+, fftw
 , Cocoa
 , CoreSymbolication
 , OpenGL
@@ -51,7 +52,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ makeWrapper cmake pkg-config git ];
-  buildInputs = [ ftgl gl2ps glew pcre zlib zstd libxml2 lz4 xz gsl xxHash libAfterImage giflib libjpeg libtiff libpng nlohmann_json python.pkgs.numpy ]
+  buildInputs = [ ftgl gl2ps glew pcre zlib zstd libxml2 lz4 xz gsl xxHash libAfterImage giflib libjpeg libtiff libpng nlohmann_json python.pkgs.numpy fftw ]
     ++ lib.optionals (!stdenv.isDarwin) [ libX11 libXpm libXft libXext libGLU libGL expat ]
     ++ lib.optionals (stdenv.isDarwin) [ Cocoa CoreSymbolication OpenGL ]
     ++ lib.optionals (implicitMT) [ tbb ]
@@ -99,7 +100,7 @@ stdenv.mkDerivation rec {
     "-Ddavix=OFF"
     "-Ddcache=OFF"
     "-Dfail-on-missing=ON"
-    "-Dfftw3=OFF"
+    "-Dfftw3=ON"
     "-Dfitsio=OFF"
     "-Dfortran=OFF"
     "-Dgfal=OFF"

--- a/nix/root/default.nix
+++ b/nix/root/default.nix
@@ -37,8 +37,8 @@
 , CoreSymbolication
 , OpenGL
 , noSplash ? false
-, implicitMT ? false
-, automaticSIMD ? false
+, implicitMT ? true
+, automaticSIMD ? true
 }:
 
 stdenv.mkDerivation rec {

--- a/nix/root/default.nix
+++ b/nix/root/default.nix
@@ -39,7 +39,7 @@
 , OpenGL
 , noSplash ? false
 , implicitMT ? true
-, automaticSIMD ? true
+, automaticSIMD ? false
 }:
 
 stdenv.mkDerivation rec {

--- a/nix/root/default.nix
+++ b/nix/root/default.nix
@@ -64,6 +64,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./sw_vers.patch
     ./hist_factory.patch
+    ./fix_file_read.patch
   ];
 
   preConfigure = ''

--- a/nix/root/default.nix
+++ b/nix/root/default.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation rec {
     ./sw_vers.patch
     ./hist_factory.patch
     ./fix_file_read.patch
+    ./roopowerlaw.patch
   ];
 
   preConfigure = ''

--- a/nix/root/default.nix
+++ b/nix/root/default.nix
@@ -66,6 +66,8 @@ stdenv.mkDerivation rec {
     ./hist_factory.patch
     ./fix_file_read.patch
     ./roopowerlaw.patch
+    # Patch below taken from root master (https://github.com/root-project/root/pull/20988), not yet tagged for release as of v6.38
+    ./extend_th3_interpolate.patch
   ];
 
   preConfigure = ''

--- a/nix/root/extend_th3_interpolate.patch
+++ b/nix/root/extend_th3_interpolate.patch
@@ -1,0 +1,93 @@
+diff --git a/hist/hist/src/TH3.cxx b/hist/hist/src/TH3.cxx
+index 1da403bf98f..0ac97c91d05 100644
+--- a/hist/hist/src/TH3.cxx
++++ b/hist/hist/src/TH3.cxx
+@@ -25,6 +25,8 @@
+ #include "TMath.h"
+ #include "TObjString.h"
+ 
++#include <algorithm>
++
+ ClassImp(TH3);
+ 
+ /** \addtogroup Hist
+@@ -1356,13 +1358,13 @@ Double_t TH3::Interpolate(Double_t, Double_t) const
+ 
+ ////////////////////////////////////////////////////////////////////////////////
+ /// Given a point P(x,y,z), Interpolate approximates the value via trilinear interpolation
+-/// based on the 8 nearest bin center points (corner of the cube surrounding the points)
+-/// The Algorithm is described in http://en.wikipedia.org/wiki/Trilinear_interpolation
+-/// The given values (x,y,z) must be between first bin center and  last bin center for each coordinate:
++/// based on the 8 nearest bin center points (corner of the cube surrounding the points).
++/// The Algorithm is described in http://en.wikipedia.org/wiki/Trilinear_interpolation.
+ ///
+-///   fXAxis.GetBinCenter(1) < x  < fXaxis.GetBinCenter(nbinX)     AND
+-///   fYAxis.GetBinCenter(1) < y  < fYaxis.GetBinCenter(nbinY)     AND
+-///   fZAxis.GetBinCenter(1) < z  < fZaxis.GetBinCenter(nbinZ)
++/// The coordinate (x,y,z) must be in the histogram range. If a coordinate falls into the first
++/// or last bin of an axis, the histogram is assumed to be constant at the edges. The interpolation
++/// proceeds as if the bin "left of" the first bin in x had the same bin content as the first bin x,
++/// and similar for the other axes.
+ 
+ Double_t TH3::Interpolate(Double_t x, Double_t y, Double_t z) const
+ {
+@@ -1378,29 +1380,41 @@ Double_t TH3::Interpolate(Double_t x, Double_t y, Double_t z) const
+    if ( z < fZaxis.GetBinCenter(ubz) ) ubz -= 1;
+    Int_t obz = ubz + 1;
+ 
++   auto GetBinCenterExtrapolate = [](TAxis const &axis, Int_t index) {
++      // Get bin centres if inside the histogram, or return the centre of an imaginary
++      // bin that's just outside the histogram, and which is as wide as the last valid bin.
++      // We need to make up a number here to not confuse the linear interpolation code below.
++      if (index == 0) {
++         return axis.GetBinCenter(1) - axis.GetBinWidth(1);
++      } else if (index == axis.GetNbins() + 1) {
++         return axis.GetBinCenter(axis.GetNbins()) + axis.GetBinWidth(axis.GetNbins());
++      } else {
++         return axis.GetBinCenter(index);
++      }
++   };
+ 
+-//    if ( IsBinUnderflow(GetBin(ubx, uby, ubz)) ||
+-//         IsBinOverflow (GetBin(obx, oby, obz)) ) {
+-   if (ubx <=0 || uby <=0 || ubz <= 0 ||
+-       obx > fXaxis.GetNbins() || oby > fYaxis.GetNbins() || obz > fZaxis.GetNbins() ) {
+-      Error("Interpolate","Cannot interpolate outside histogram domain.");
+-      return 0;
+-   }
+-
+-   Double_t xw = fXaxis.GetBinCenter(obx) - fXaxis.GetBinCenter(ubx);
+-   Double_t yw = fYaxis.GetBinCenter(oby) - fYaxis.GetBinCenter(uby);
+-   Double_t zw = fZaxis.GetBinCenter(obz) - fZaxis.GetBinCenter(ubz);
++   Double_t xw = GetBinCenterExtrapolate(fXaxis, obx) - GetBinCenterExtrapolate(fXaxis, ubx);
++   Double_t yw = GetBinCenterExtrapolate(fYaxis, oby) - GetBinCenterExtrapolate(fYaxis, uby);
++   Double_t zw = GetBinCenterExtrapolate(fZaxis, obz) - GetBinCenterExtrapolate(fZaxis, ubz);
+ 
+-   Double_t xd = (x - fXaxis.GetBinCenter(ubx)) / xw;
+-   Double_t yd = (y - fYaxis.GetBinCenter(uby)) / yw;
+-   Double_t zd = (z - fZaxis.GetBinCenter(ubz)) / zw;
++   Double_t xd = (x - GetBinCenterExtrapolate(fXaxis, ubx)) / xw;
++   Double_t yd = (y - GetBinCenterExtrapolate(fYaxis, uby)) / yw;
++   Double_t zd = (z - GetBinCenterExtrapolate(fZaxis, ubz)) / zw;
+ 
++   auto GetBinContentNoOverflow = [this](int ix, int iy, int iz) {
++      // When a bin is outside the histogram range, return the last value inside
++      // the range. That is, make the histogram constant at its edges.
++      ix = std::clamp(ix, 1, GetNbinsX());
++      iy = std::clamp(iy, 1, GetNbinsY());
++      iz = std::clamp(iz, 1, GetNbinsZ());
+ 
+-   Double_t v[] = { GetBinContent( ubx, uby, ubz ), GetBinContent( ubx, uby, obz ),
+-                    GetBinContent( ubx, oby, ubz ), GetBinContent( ubx, oby, obz ),
+-                    GetBinContent( obx, uby, ubz ), GetBinContent( obx, uby, obz ),
+-                    GetBinContent( obx, oby, ubz ), GetBinContent( obx, oby, obz ) };
++      return GetBinContent(ix, iy, iz);
++   };
+ 
++   Double_t v[] = {GetBinContentNoOverflow(ubx, uby, ubz), GetBinContentNoOverflow(ubx, uby, obz),
++                   GetBinContentNoOverflow(ubx, oby, ubz), GetBinContentNoOverflow(ubx, oby, obz),
++                   GetBinContentNoOverflow(obx, uby, ubz), GetBinContentNoOverflow(obx, uby, obz),
++                   GetBinContentNoOverflow(obx, oby, ubz), GetBinContentNoOverflow(obx, oby, obz)};
+ 
+    Double_t i1 = v[0] * (1 - zd) + v[1] * zd;
+    Double_t i2 = v[2] * (1 - zd) + v[3] * zd;

--- a/nix/root/fix_file_read.patch
+++ b/nix/root/fix_file_read.patch
@@ -1,0 +1,71 @@
+From e48ba0494b8f26b8b30a3b758eba47f8295768ed Mon Sep 17 00:00:00 2001
+From: Philippe Canal <pcanal@fnal.gov>
+Date: Fri, 3 Mar 2023 13:23:45 -0600
+Subject: [PATCH] fBits read: preserve kIsOnHeap, always set kNotDeleted.
+
+Rather than reading from the file the value of kIsOnHeap, preserve the value that was
+calculated at object creation time (i.e. in the current execution).  For example, for
+an embedded object (inside an object created on the heap or stack), the bit always
+need to be off (i.e. it can never be explicitly deleted)
+---
+ core/base/src/TObject.cxx             | 3 ++-
+ io/io/src/TStreamerInfoActions.cxx    | 2 ++
+ io/io/src/TStreamerInfoReadBuffer.cxx | 6 +++++-
+ 3 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/core/base/src/TObject.cxx b/core/base/src/TObject.cxx
+index 822562351c..31416e2107 100644
+--- a/core/base/src/TObject.cxx
++++ b/core/base/src/TObject.cxx
+@@ -880,8 +880,9 @@ void TObject::Streamer(TBuffer &R__b)
+    if (R__b.IsReading()) {
+       R__b.SkipVersion(); // Version_t R__v = R__b.ReadVersion(); if (R__v) { }
+       R__b >> fUniqueID;
++      const UInt_t isonheap = fBits & kIsOnHeap; // Record how this instance was actually allocated.
+       R__b >> fBits;
+-      fBits |= kIsOnHeap;  // by definition de-serialized object is on heap
++      fBits |= isonheap | kNotDeleted;  // by definition de-serialized object are not yet deleted.
+       if (TestBit(kIsReferenced)) {
+          //if the object is referenced, we must read its old address
+          //and store it in the ProcessID map in gROOT
+diff --git a/io/io/src/TStreamerInfoActions.cxx b/io/io/src/TStreamerInfoActions.cxx
+index a615e44434..7cdc0aeab5 100644
+--- a/io/io/src/TStreamerInfoActions.cxx
++++ b/io/io/src/TStreamerInfoActions.cxx
+@@ -236,7 +236,9 @@ namespace TStreamerInfoActions
+       UInt_t *x = (UInt_t*)( ((char*)addr) + config->fOffset );
+       // Idea: Implement buf.ReadBasic/Primitive to avoid the return value
+       // Idea: This code really belongs inside TBuffer[File]
++      const UInt_t isonheap = *x & TObject::kIsOnHeap; // Record how this instance was actually allocated.
+       buf >> *x;
++      *x |= isonheap | TObject::kNotDeleted;  // by definition de-serialized object are not yet deleted.
+ 
+       if ((*x & kIsReferenced) != 0) {
+          HandleReferencedTObject(buf,addr,config);
+diff --git a/io/io/src/TStreamerInfoReadBuffer.cxx b/io/io/src/TStreamerInfoReadBuffer.cxx
+index e9054d8d4e..5b84e330f9 100644
+--- a/io/io/src/TStreamerInfoReadBuffer.cxx
++++ b/io/io/src/TStreamerInfoReadBuffer.cxx
+@@ -609,6 +609,7 @@ Int_t TStreamerInfo::ReadBufferConv(TBuffer &b, const T &arr,  const TCompInfo *
+          DOLOOP {
+             UInt_t u;
+             b >> u;
++            u |= kNotDeleted;  // by definition de-serialized object are not yet deleted.
+             if ((u & kIsReferenced) != 0) {
+                UShort_t pidf;
+                b >> pidf;
+@@ -1019,7 +1020,10 @@ Int_t TStreamerInfo::ReadBuffer(TBuffer &b, const T &arr,
+          // special case for TObject::fBits in case of a referenced object
+          case TStreamerInfo::kBits: {
+             DOLOOP {
+-               UInt_t *x=(UInt_t*)(arr[k]+ioffset); b >> *x;
++               UInt_t *x=(UInt_t*)(arr[k]+ioffset);
++               const UInt_t isonheap = *x & TObject::kIsOnHeap; // Record how this instance was actually allocated.
++               b >> *x;
++               *x |= isonheap | TObject::kNotDeleted;  // by definition de-serialized object are not yet deleted.
+                if ((*x & kIsReferenced) != 0) {
+                   UShort_t pidf;
+                   b >> pidf;
+-- 
+2.25.1
+

--- a/nix/root/roopowerlaw.patch
+++ b/nix/root/roopowerlaw.patch
@@ -1,0 +1,233 @@
+diff --git a/roofit/batchcompute/inc/RooBatchCompute.h b/roofit/batchcompute/inc/RooBatchCompute.h
+index da3dd9c8e0..1239eb60f9 100644
+--- a/roofit/batchcompute/inc/RooBatchCompute.h
++++ b/roofit/batchcompute/inc/RooBatchCompute.h
+@@ -55,6 +55,7 @@ namespace RooBatchCompute {
+     virtual RooSpan<double> computeNovosibirsk(const RooAbsReal*, RunContext&, RooSpan<const double> x, RooSpan<const double> peak, RooSpan<const double> width, RooSpan<const double> tail) = 0;
+     virtual RooSpan<double> computePoisson(const RooAbsReal*, RunContext&, RooSpan<const double> x, RooSpan<const double> mean, bool protectNegative, bool noRounding) = 0;
+     virtual void computePolynomial(size_t batchSize, double * __restrict output, const double * __restrict const xData, int lowestOrder, std::vector<BracketAdapterWithMask> &coef) = 0;
++    virtual RooSpan<double> computePowerLaw(const RooAbsReal*, RunContext&, RooSpan<const double> x, RooSpan<const double> c) = 0;
+     virtual RooSpan<double> computeVoigtian(const RooAbsReal*, RunContext&, RooSpan<const double> x, RooSpan<const double> mean, RooSpan<const double> width, RooSpan<const double> sigma) = 0;
+   };
+ 
+diff --git a/roofit/batchcompute/src/RooBatchCompute.cxx b/roofit/batchcompute/src/RooBatchCompute.cxx
+index 04d8637533..089d9279f5 100644
+--- a/roofit/batchcompute/src/RooBatchCompute.cxx
++++ b/roofit/batchcompute/src/RooBatchCompute.cxx
+@@ -614,6 +614,18 @@ namespace RooBatchCompute {
+       }
+     }
+ 
++//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
++
++    struct PowerLawComputer {
++      template<class Tx, class Tc>
++      void run(size_t n, double* __restrict output, Tx x, Tc c) const
++      {
++        for (size_t i = 0; i < n; ++i) {
++          output[i] = std::pow(x[i], c[i]);
++        }
++      }
++    };
++
+ //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+ 
+     struct VoigtianComputer {
+@@ -754,6 +766,9 @@ namespace RooBatchCompute {
+         void computePolynomial(size_t batchSize, double* __restrict output, const double* __restrict const X, int lowestOrder, std::vector<BracketAdapterWithMask>& coefList)  override {
+           startComputationPolynomial(batchSize, output, X, lowestOrder, coefList);
+         }
++        RooSpan<double> computePowerLaw(const RooAbsReal* caller, RunContext& evalData, RooSpan<const double> x, RooSpan<const double> c)  override {
++          return startComputation(caller, evalData, PowerLawComputer{}, x, c);
++        }
+         RooSpan<double> computeVoigtian(const RooAbsReal* caller, RunContext& evalData, RooSpan<const double> x, RooSpan<const double> mean, RooSpan<const double> width, RooSpan<const double> sigma)  override {
+           return startComputation(caller, evalData, VoigtianComputer{}, x, mean, width, sigma);
+         }
+diff --git a/roofit/roofit/CMakeLists.txt b/roofit/roofit/CMakeLists.txt
+index ec00c119f8..2b1d1f6de8 100644
+--- a/roofit/roofit/CMakeLists.txt
++++ b/roofit/roofit/CMakeLists.txt
+@@ -60,6 +60,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFit
+     RooParamHistFunc.h
+     RooPoisson.h
+     RooPolynomial.h
++    RooPowerLaw.h
+     RooStepFunction.h
+     RooTFnBinding.h
+     RooTFnPdfBinding.h
+@@ -120,6 +121,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFit
+     src/RooParamHistFunc.cxx
+     src/RooPoisson.cxx
+     src/RooPolynomial.cxx
++    src/RooPowerLaw.cxx
+     src/RooStepFunction.cxx
+     src/RooTFnBinding.cxx
+     src/RooTFnPdfBinding.cxx
+diff --git a/roofit/roofit/inc/LinkDef1.h b/roofit/roofit/inc/LinkDef1.h
+index 77c410765c..3971d56f9b 100644
+--- a/roofit/roofit/inc/LinkDef1.h
++++ b/roofit/roofit/inc/LinkDef1.h
+@@ -33,6 +33,7 @@
+ #pragma link C++ class RooParamHistFunc+ ;
+ #pragma link C++ class RooParametricStepFunction+ ;
+ #pragma link C++ class RooPolynomial+ ;
++#pragma link C++ class RooPowerLaw+ ;
+ #pragma link C++ class RooUnblindCPAsymVar+ ;
+ #pragma link C++ class RooUnblindOffset+ ;
+ #pragma link C++ class RooUnblindPrecision+ ;
+diff --git a/roofit/roofit/inc/RooPowerLaw.h b/roofit/roofit/inc/RooPowerLaw.h
+new file mode 100644
+index 0000000000..89b7411ea3
+--- /dev/null
++++ b/roofit/roofit/inc/RooPowerLaw.h
+@@ -0,0 +1,48 @@
++/*****************************************************************************
++ * Project: RooFit                                                           *
++ * Package: RooFitModels                                                     *
++ *    File: $Id: RooPowerLaw.h,v 1.10 2007/07/12 20:30:49 wouter Exp $
++ * Authors:                                                                  *
++ *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
++ *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
++ *                                                                           *
++ * Copyright (c) 2000-2005, Regents of the University of California          *
++ *                          and Stanford University. All rights reserved.    *
++ *                                                                           *
++ * Redistribution and use in source and binary forms,                        *
++ * with or without modification, are permitted according to the terms        *
++ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
++ *****************************************************************************/
++#ifndef ROO_POWERLAW
++#define ROO_POWERLAW
++
++#include "RooAbsPdf.h"
++#include "RooRealProxy.h"
++
++class RooRealVar;
++class RooAbsReal;
++
++class RooPowerLaw : public RooAbsPdf {
++public:
++  RooPowerLaw() {} ;
++  RooPowerLaw(const char *name, const char *title,
++       RooAbsReal& _x, RooAbsReal& _c);
++  RooPowerLaw(const RooPowerLaw& other, const char* name=0);
++  virtual TObject* clone(const char* newname) const override { return new RooPowerLaw(*this,newname); }
++  inline virtual ~RooPowerLaw() { }
++
++  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
++  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;
++
++protected:
++  RooRealProxy x;
++  RooRealProxy c;
++
++  Double_t evaluate() const override;
++  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
++
++private:
++  ClassDefOverride(RooPowerLaw,1) // PowerLaw PDF
++};
++
++#endif
+\ No newline at end of file
+diff --git a/roofit/roofit/src/RooPowerLaw.cxx b/roofit/roofit/src/RooPowerLaw.cxx
+new file mode 100644
+index 0000000000..b755758dd2
+--- /dev/null
++++ b/roofit/roofit/src/RooPowerLaw.cxx
+@@ -0,0 +1,94 @@
++/*****************************************************************************
++ * Project: RooFit                                                           *
++ * Package: RooFitModels                                                     *
++ * @(#)root/roofit:$Id$
++ * Authors:                                                                  *
++ *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
++ *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
++ *                                                                           *
++ * Copyright (c) 2000-2005, Regents of the University of California          *
++ *                          and Stanford University. All rights reserved.    *
++ *                                                                           *
++ * Redistribution and use in source and binary forms,                        *
++ * with or without modification, are permitted according to the terms        *
++ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
++ *****************************************************************************/
++
++/** \class RooPowerLaw
++    \ingroup Roofit
++
++Power law PDF. It computes
++\f[
++  \mathrm{RooPowerLaw}(x, n) = \mathcal{N} \cdot x^n,
++\f]
++where \f$ \mathcal{N} \f$ is a normalisation constant that depends on the
++range and values of the arguments.
++
++Note: Adapted from RooExponential for RDX run 2 analysis.
++**/
++
++#include "RooPowerLaw.h"
++
++#include "RooRealVar.h"
++#include "RooBatchCompute.h"
++
++
++#include <cmath>
++
++ClassImp(RooPowerLaw);
++
++////////////////////////////////////////////////////////////////////////////////
++
++RooPowerLaw::RooPowerLaw(const char *name, const char *title,
++                RooAbsReal& _x, RooAbsReal& _c) :
++  RooAbsPdf(name, title),
++  x("x","Dependent",this,_x),
++  c("c","Exponent",this,_c)
++{
++}
++
++////////////////////////////////////////////////////////////////////////////////
++
++RooPowerLaw::RooPowerLaw(const RooPowerLaw& other, const char* name) :
++  RooAbsPdf(other, name), x("x",this,other.x), c("c",this,other.c)
++{
++}
++
++////////////////////////////////////////////////////////////////////////////////
++
++Double_t RooPowerLaw::evaluate() const{
++  return std::pow(x, c);
++}
++
++////////////////////////////////////////////////////////////////////////////////
++
++Int_t RooPowerLaw::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* /*rangeName*/) const
++{
++  if (matchArgs(allVars,analVars,x)) return 1;
++  return 0 ;
++}
++
++////////////////////////////////////////////////////////////////////////////////
++
++Double_t RooPowerLaw::analyticalIntegral(Int_t code, const char* rangeName) const
++{
++  assert(code == 1);
++
++  auto& constant  = c;
++  auto& integrand = x;
++
++  if (constant == 0.0) {
++    return integrand.max(rangeName) - integrand.min(rangeName);
++  }
++
++  auto k = constant + 1.;
++
++  return (std::pow(integrand.max(rangeName), k) - std::pow(integrand.min(rangeName), k))
++      / k;
++}
++
++////////////////////////////////////////////////////////////////////////////////
++/// Compute multiple values of Exponential distribution.
++RooSpan<double> RooPowerLaw::evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const {
++  return RooBatchCompute::dispatch->computePowerLaw(this, evalData, x->getValues(evalData, normSet), c->getValues(evalData, normSet));
++}
+\ No newline at end of file

--- a/nix/root/roopowerlaw.patch
+++ b/nix/root/roopowerlaw.patch
@@ -1,17 +1,17 @@
 diff --git a/roofit/batchcompute/inc/RooBatchCompute.h b/roofit/batchcompute/inc/RooBatchCompute.h
-index da3dd9c8e0..1239eb60f9 100644
+index da3dd9c8e0..0a81c98153 100644
 --- a/roofit/batchcompute/inc/RooBatchCompute.h
 +++ b/roofit/batchcompute/inc/RooBatchCompute.h
 @@ -55,6 +55,7 @@ namespace RooBatchCompute {
      virtual RooSpan<double> computeNovosibirsk(const RooAbsReal*, RunContext&, RooSpan<const double> x, RooSpan<const double> peak, RooSpan<const double> width, RooSpan<const double> tail) = 0;
      virtual RooSpan<double> computePoisson(const RooAbsReal*, RunContext&, RooSpan<const double> x, RooSpan<const double> mean, bool protectNegative, bool noRounding) = 0;
      virtual void computePolynomial(size_t batchSize, double * __restrict output, const double * __restrict const xData, int lowestOrder, std::vector<BracketAdapterWithMask> &coef) = 0;
-+    virtual RooSpan<double> computePowerLaw(const RooAbsReal*, RunContext&, RooSpan<const double> x, RooSpan<const double> c) = 0;
++    virtual RooSpan<double> computePowerLaw(const RooAbsReal*, RunContext&, RooSpan<const double> x, RooSpan<const double> x0, RooSpan<const double> c) = 0;
      virtual RooSpan<double> computeVoigtian(const RooAbsReal*, RunContext&, RooSpan<const double> x, RooSpan<const double> mean, RooSpan<const double> width, RooSpan<const double> sigma) = 0;
    };
  
 diff --git a/roofit/batchcompute/src/RooBatchCompute.cxx b/roofit/batchcompute/src/RooBatchCompute.cxx
-index 04d8637533..089d9279f5 100644
+index 04d8637533..f58a7ecb1b 100644
 --- a/roofit/batchcompute/src/RooBatchCompute.cxx
 +++ b/roofit/batchcompute/src/RooBatchCompute.cxx
 @@ -614,6 +614,18 @@ namespace RooBatchCompute {
@@ -21,11 +21,11 @@ index 04d8637533..089d9279f5 100644
 +//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 +
 +    struct PowerLawComputer {
-+      template<class Tx, class Tc>
-+      void run(size_t n, double* __restrict output, Tx x, Tc c) const
++      template<class Tx, class Tx0, class Tc>
++      void run(size_t n, double* __restrict output, Tx x, Tx0 x0, Tc c) const
 +      {
 +        for (size_t i = 0; i < n; ++i) {
-+          output[i] = std::pow(x[i], c[i]);
++          output[i] = std::pow(x[i]-x0[i], c[i]);
 +        }
 +      }
 +    };
@@ -37,8 +37,8 @@ index 04d8637533..089d9279f5 100644
          void computePolynomial(size_t batchSize, double* __restrict output, const double* __restrict const X, int lowestOrder, std::vector<BracketAdapterWithMask>& coefList)  override {
            startComputationPolynomial(batchSize, output, X, lowestOrder, coefList);
          }
-+        RooSpan<double> computePowerLaw(const RooAbsReal* caller, RunContext& evalData, RooSpan<const double> x, RooSpan<const double> c)  override {
-+          return startComputation(caller, evalData, PowerLawComputer{}, x, c);
++        RooSpan<double> computePowerLaw(const RooAbsReal* caller, RunContext& evalData, RooSpan<const double> x, RooSpan<const double> x0, RooSpan<const double> c)  override {
++          return startComputation(caller, evalData, PowerLawComputer{}, x, x0, c);
 +        }
          RooSpan<double> computeVoigtian(const RooAbsReal* caller, RunContext& evalData, RooSpan<const double> x, RooSpan<const double> mean, RooSpan<const double> width, RooSpan<const double> sigma)  override {
            return startComputation(caller, evalData, VoigtianComputer{}, x, mean, width, sigma);
@@ -77,10 +77,10 @@ index 77c410765c..3971d56f9b 100644
  #pragma link C++ class RooUnblindPrecision+ ;
 diff --git a/roofit/roofit/inc/RooPowerLaw.h b/roofit/roofit/inc/RooPowerLaw.h
 new file mode 100644
-index 0000000000..89b7411ea3
+index 0000000000..f13816bca0
 --- /dev/null
 +++ b/roofit/roofit/inc/RooPowerLaw.h
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,49 @@
 +/*****************************************************************************
 + * Project: RooFit                                                           *
 + * Package: RooFitModels                                                     *
@@ -109,7 +109,7 @@ index 0000000000..89b7411ea3
 +public:
 +  RooPowerLaw() {} ;
 +  RooPowerLaw(const char *name, const char *title,
-+       RooAbsReal& _x, RooAbsReal& _c);
++       RooAbsReal& _x, RooAbsReal& _x0, RooAbsReal& _c);
 +  RooPowerLaw(const RooPowerLaw& other, const char* name=0);
 +  virtual TObject* clone(const char* newname) const override { return new RooPowerLaw(*this,newname); }
 +  inline virtual ~RooPowerLaw() { }
@@ -119,6 +119,7 @@ index 0000000000..89b7411ea3
 +
 +protected:
 +  RooRealProxy x;
++  RooRealProxy x0;
 +  RooRealProxy c;
 +
 +  Double_t evaluate() const override;
@@ -132,10 +133,10 @@ index 0000000000..89b7411ea3
 \ No newline at end of file
 diff --git a/roofit/roofit/src/RooPowerLaw.cxx b/roofit/roofit/src/RooPowerLaw.cxx
 new file mode 100644
-index 0000000000..b755758dd2
+index 0000000000..81a2c972de
 --- /dev/null
 +++ b/roofit/roofit/src/RooPowerLaw.cxx
-@@ -0,0 +1,94 @@
+@@ -0,0 +1,95 @@
 +/*****************************************************************************
 + * Project: RooFit                                                           *
 + * Package: RooFitModels                                                     *
@@ -157,7 +158,7 @@ index 0000000000..b755758dd2
 +
 +Power law PDF. It computes
 +\f[
-+  \mathrm{RooPowerLaw}(x, n) = \mathcal{N} \cdot x^n,
++  \mathrm{RooPowerLaw}(x, x_0, c) = \mathcal{N} \cdot (x - x_0)^c,
 +\f]
 +where \f$ \mathcal{N} \f$ is a normalisation constant that depends on the
 +range and values of the arguments.
@@ -178,9 +179,10 @@ index 0000000000..b755758dd2
 +////////////////////////////////////////////////////////////////////////////////
 +
 +RooPowerLaw::RooPowerLaw(const char *name, const char *title,
-+                RooAbsReal& _x, RooAbsReal& _c) :
++                RooAbsReal& _x, RooAbsReal& _x0, RooAbsReal& _c) :
 +  RooAbsPdf(name, title),
 +  x("x","Dependent",this,_x),
++  x0("x0","Shift",this,_x0),
 +  c("c","Exponent",this,_c)
 +{
 +}
@@ -188,14 +190,14 @@ index 0000000000..b755758dd2
 +////////////////////////////////////////////////////////////////////////////////
 +
 +RooPowerLaw::RooPowerLaw(const RooPowerLaw& other, const char* name) :
-+  RooAbsPdf(other, name), x("x",this,other.x), c("c",this,other.c)
++  RooAbsPdf(other, name), x("x",this,other.x), x0("x0",this,other.x0), c("c",this,other.c)
 +{
 +}
 +
 +////////////////////////////////////////////////////////////////////////////////
 +
 +Double_t RooPowerLaw::evaluate() const{
-+  return std::pow(x, c);
++  return std::pow(x - x0, c);
 +}
 +
 +////////////////////////////////////////////////////////////////////////////////
@@ -215,19 +217,19 @@ index 0000000000..b755758dd2
 +  auto& constant  = c;
 +  auto& integrand = x;
 +
-+  if (constant == 0.0) {
-+    return integrand.max(rangeName) - integrand.min(rangeName);
++  if (constant == -1.0) {
++    return std::log(integrand.max(rangeName) - x0) - std::log(integrand.min(rangeName) - x0);
 +  }
 +
 +  auto k = constant + 1.;
 +
-+  return (std::pow(integrand.max(rangeName), k) - std::pow(integrand.min(rangeName), k))
++  return (std::pow(integrand.max(rangeName) - x0, k) - std::pow(integrand.min(rangeName) - x0, k))
 +      / k;
 +}
 +
 +////////////////////////////////////////////////////////////////////////////////
 +/// Compute multiple values of Exponential distribution.
 +RooSpan<double> RooPowerLaw::evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const {
-+  return RooBatchCompute::dispatch->computePowerLaw(this, evalData, x->getValues(evalData, normSet), c->getValues(evalData, normSet));
++  return RooBatchCompute::dispatch->computePowerLaw(this, evalData, x->getValues(evalData, normSet), x0->getValues(evalData, normSet), c->getValues(evalData, normSet));
 +}
 \ No newline at end of file

--- a/nix/root/roopowerlaw.patch
+++ b/nix/root/roopowerlaw.patch
@@ -9,7 +9,7 @@ index da3dd9c8e0..0a81c98153 100644
 +    virtual RooSpan<double> computePowerLaw(const RooAbsReal*, RunContext&, RooSpan<const double> x, RooSpan<const double> x0, RooSpan<const double> c) = 0;
      virtual RooSpan<double> computeVoigtian(const RooAbsReal*, RunContext&, RooSpan<const double> x, RooSpan<const double> mean, RooSpan<const double> width, RooSpan<const double> sigma) = 0;
    };
- 
+
 diff --git a/roofit/batchcompute/src/RooBatchCompute.cxx b/roofit/batchcompute/src/RooBatchCompute.cxx
 index 04d8637533..f58a7ecb1b 100644
 --- a/roofit/batchcompute/src/RooBatchCompute.cxx
@@ -17,7 +17,7 @@ index 04d8637533..f58a7ecb1b 100644
 @@ -614,6 +614,18 @@ namespace RooBatchCompute {
        }
      }
- 
+
 +//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 +
 +    struct PowerLawComputer {
@@ -31,7 +31,7 @@ index 04d8637533..f58a7ecb1b 100644
 +    };
 +
  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
- 
+
      struct VoigtianComputer {
 @@ -754,6 +766,9 @@ namespace RooBatchCompute {
          void computePolynomial(size_t batchSize, double* __restrict output, const double* __restrict const X, int lowestOrder, std::vector<BracketAdapterWithMask>& coefList)  override {
@@ -77,7 +77,7 @@ index 77c410765c..3971d56f9b 100644
  #pragma link C++ class RooUnblindPrecision+ ;
 diff --git a/roofit/roofit/inc/RooPowerLaw.h b/roofit/roofit/inc/RooPowerLaw.h
 new file mode 100644
-index 0000000000..f13816bca0
+index 0000000000..6837529f52
 --- /dev/null
 +++ b/roofit/roofit/inc/RooPowerLaw.h
 @@ -0,0 +1,49 @@
@@ -130,13 +130,12 @@ index 0000000000..f13816bca0
 +};
 +
 +#endif
-\ No newline at end of file
 diff --git a/roofit/roofit/src/RooPowerLaw.cxx b/roofit/roofit/src/RooPowerLaw.cxx
 new file mode 100644
-index 0000000000..81a2c972de
+index 0000000000..a1b1a27094
 --- /dev/null
 +++ b/roofit/roofit/src/RooPowerLaw.cxx
-@@ -0,0 +1,95 @@
+@@ -0,0 +1,113 @@
 +/*****************************************************************************
 + * Project: RooFit                                                           *
 + * Package: RooFitModels                                                     *
@@ -160,7 +159,7 @@ index 0000000000..81a2c972de
 +\f[
 +  \mathrm{RooPowerLaw}(x, x_0, c) = \mathcal{N} \cdot (x - x_0)^c,
 +\f]
-+where \f$ \mathcal{N} \f$ is a normalisation constant that depends on the
++where \f$ \mathcal{N} \f$ is a normalization constant that depends on the
 +range and values of the arguments.
 +
 +Note: Adapted from RooExponential for RDX run 2 analysis.
@@ -171,6 +170,7 @@ index 0000000000..81a2c972de
 +#include "RooRealVar.h"
 +#include "RooBatchCompute.h"
 +
++#include "TError.h"
 +
 +#include <cmath>
 +
@@ -197,7 +197,11 @@ index 0000000000..81a2c972de
 +////////////////////////////////////////////////////////////////////////////////
 +
 +Double_t RooPowerLaw::evaluate() const{
-+  return std::pow(x - x0, c);
++  if (x > x0) {
++    return std::pow(x - x0, c);
++  } else {
++    return 0.;
++  }
 +}
 +
 +////////////////////////////////////////////////////////////////////////////////
@@ -212,24 +216,36 @@ index 0000000000..81a2c972de
 +
 +Double_t RooPowerLaw::analyticalIntegral(Int_t code, const char* rangeName) const
 +{
-+  assert(code == 1);
++  R__ASSERT(code == 1);
 +
 +  auto& constant  = c;
 +  auto& integrand = x;
 +
++  double max = integrand.max(rangeName);
++  double min = integrand.min(rangeName);
++
++  // If the whole integration region is below threshold, return 0
++  if (max <= x0) {
++    return 0.;
++  }
++
++  // If only part of the integration region is below threshold, integrate from x0 to max
++  if (min < x0) {
++    min = x0;
++  }
++
 +  if (constant == -1.0) {
-+    return std::log(integrand.max(rangeName) - x0) - std::log(integrand.min(rangeName) - x0);
++    return std::log(max - x0) - std::log(min - x0);
 +  }
 +
 +  auto k = constant + 1.;
 +
-+  return (std::pow(integrand.max(rangeName) - x0, k) - std::pow(integrand.min(rangeName) - x0, k))
++  return (std::pow(max - x0, k) - std::pow(min - x0, k))
 +      / k;
 +}
 +
 +////////////////////////////////////////////////////////////////////////////////
-+/// Compute multiple values of Exponential distribution.
++/// Compute multiple values of power law distribution.
 +RooSpan<double> RooPowerLaw::evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const {
 +  return RooBatchCompute::dispatch->computePowerLaw(this, evalData, x->getValues(evalData, normSet), x0->getValues(evalData, normSet), c->getValues(evalData, normSet));
 +}
-\ No newline at end of file

--- a/root-curated.code-workspace
+++ b/root-curated.code-workspace
@@ -1,0 +1,102 @@
+{
+    "extensions": {
+        "recommendations": [
+            "albertopdrf.root-file-viewer",
+            "eamodio.gitlens",
+            "eeyore.yapf",
+            "ms-python.flake8",
+            "ms-python.python",
+            "ms-python.vscode-pylance",
+            "ms-vscode.cpptools",
+            "twxs.cmake",
+            "trond-snekvik.simple-rst",
+            "davidanson.vscode-markdownlint",
+            "streetsidesoftware.code-spell-checker",
+            "bbenoist.Nix"
+        ]
+    },
+    "folders": [
+        {
+            "path": "./"
+        }
+    ],
+    "settings": {
+        "C_Cpp.configurationWarnings": "disabled",
+        "C_Cpp.default.browse.databaseFilename": "${workspaceFolder}/.vscode-cpptools/browse.VC.db",
+        "C_Cpp.default.browse.path": [],
+        "C_Cpp.default.cStandard": "c11",
+        "C_Cpp.default.compileCommands": "",
+        "C_Cpp.default.compilerPath": "/usr/bin/g++",
+        "C_Cpp.default.configurationProvider": "nonexistent.extension",
+        "C_Cpp.default.cppStandard": "c++17",
+        "C_Cpp.default.defines": [],
+        "C_Cpp.default.includePath": [],
+        "C_Cpp.default.intelliSenseMode": "gcc-x64",
+        "C_Cpp.files.exclude": {
+            "**/.vscode": true,
+            "**/.vscode-cpptools/": true,
+            "/usr": true
+        },
+        "C_Cpp.intelliSenseCachePath": "${workspaceFolder}/.vscode-cpptools/cache",
+        "C_Cpp.intelliSenseCacheSize": 0,
+        "C_Cpp.workspaceParsingPriority": "low",
+        "[python]": {
+            "editor.defaultFormatter": "eeyore.yapf"
+        },
+        "cSpell.diagnosticLevel": "Hint",
+        "cSpell.enabledLanguageIds": [
+            "c",
+            "cpp",
+            "markdown",
+            "python",
+            "restructuredtext",
+            "text"
+        ],
+        "cSpell.language": "en,en-GB",
+        "cSpell.languageSettings": [
+            {
+                "includeRegExpList": [
+                    "/#.*/",
+                    "/('''|\"\"\")[^\\1]+?\\1/g",
+                    "strings"
+                ],
+                "languageId": "python"
+            },
+            {
+                "allowCompoundWords": false,
+                "ignoreRegExpList": [
+                    "/#include.*/"
+                ],
+                "includeRegExpList": [
+                    "CStyleComment",
+                    "string"
+                ],
+                "languageId": "cpp,c"
+            }
+        ],
+        "files.associations": {
+            "*.C": "cpp",
+            "*.icpp": "cpp",
+            "cmath": "cpp",
+            "iostream": "cpp",
+            "ostream": "cpp",
+            "chrono": "cpp",
+            "functional": "cpp"
+        },
+        "files.trimTrailingWhitespace": true,
+        "flake8.args": [
+            "--select=F,E71,E9,W1,W6"
+        ],
+        "python.defaultInterpreterPath": "/usr/bin/python3",
+        "python.languageServer": "Pylance",
+        "remote.downloadExtensionsLocally": true,
+        "restructuredtext.linter.disabledLinters": [
+            "doc8",
+            "rst-lint",
+            "rstcheck"
+        ],
+        "restructuredtext.linter.run": "off",
+        "telemetry.enableCrashReporter": false,
+        "window.title": "${dirty}${activeEditorShort}${separator}${rootPath}"
+    }
+}

--- a/root-curated.code-workspace
+++ b/root-curated.code-workspace
@@ -8,8 +8,7 @@
             "ms-python.python",
             "ms-python.vscode-pylance",
             "ms-vscode.cpptools",
-            "twxs.cmake",
-            "trond-snekvik.simple-rst",
+            "ms-vscode.makefile-tools",
             "davidanson.vscode-markdownlint",
             "streetsidesoftware.code-spell-checker",
             "bbenoist.Nix"


### PR DESCRIPTION
- Enable root's ImplicitMT, which can speed up downstream code execution.
  - [Implicit multi-threading](https://root.cern/manual/multi_threading/#implicit-multi-threading) allows multi-threaded execution in some root classes (e.g. TH1, TTree and RDataFrame). Note that it must still be enabled during execution by calling `ROOT::EnableImplicitMT()`, and is otherwise disabled by default.
- Enable FFTW3 when building root. This is necessary to perform fast PDF convolutions with [RooFFTConvPdf](https://root.cern.ch/doc/v624/classRooFFTConvPdf.html). AFAIK, FFTW3 is not used anywhere else in ROOT.
- Enable root parallel building. By default, seems to set the number of compilation jobs to the number of available threads. However, this behavior can be controlled with the [`--cores` ](https://nixos.org/manual/nix/stable/advanced-topics/cores-vs-jobs) flag.
- Implement custom RooFit PDF `RooPowerLaw`, defined as $(x - x_0)^c$ for $x > x_0$ and $0$ otherwise. Note that starting with ROOT v6.32, RooFit includes the PDF [RooPowerSum](https://root.cern.ch/doc/master/classRooPowerSum.html), which _in principle_ makes this patch unecessary. However, to shift the threshold with `RooPowerSum` ones needs to transform the observable with `RooFormulaVar` or `RooLinearVar`, which triggers numeric integration and slows down the fit (though this shouldn't be triggered with `RooLinearVar` and hopefully has been fixed in newer versions). This is not the case with the custom `RooPowerLaw`.
- Add VSCode configuration file.