### PR TITLE
Update to ROOT 6.32

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,20 +37,20 @@
           inherit (pkgs) vdt git
             # root
             root
-            root_6_24_02
+            root_6_32_16
             root_6_16_00
             root_6_12_06
             root_5_34_38
             # hammer
             hammer-phys
-            hammer-phys-w_root_6_24
+            hammer-phys-w_root_6_32
             hammer-phys-w_root_6_16
             hammer-phys-w_root_6_12
             # hammer dev
             hammer-phys-dev
             # roounfold
             roounfold
-            roounfold-w_root_6_24
+            roounfold-w_root_6_32
             roounfold-w_root_6_16
             roounfold-w_root_6_12
             # else

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -50,13 +50,13 @@ final: prev:
   roounfold = prev.callPackage ./roounfold { };
   roounfold_1_1 = prev.callPackage ./roounfold_1_1 { };
 
-  # ROOT 6.24 stack
-  root_6_24_02 = final.root;
-  hammer-phys-w_root_6_24 = prev.callPackage ./hammer-phys {
-    root = final.root_6_24_02;
+  # ROOT 6.32 stack
+  root_6_32_16 = final.root;
+  hammer-phys-w_root_6_32 = prev.callPackage ./hammer-phys {
+    root = final.root_6_32_16;
   };
-  roounfold-w_root_6_24 = prev.callPackage ./roounfold {
-    root = final.root_6_24_02;
+  roounfold-w_root_6_32 = prev.callPackage ./roounfold {
+    root = final.root_6_32_16;
   };
 
   # ROOT 6.16 stack

--- a/nix/root/default.nix
+++ b/nix/root/default.nix
@@ -66,6 +66,7 @@ stdenv.mkDerivation rec {
     # ./hist_factory.patch  # Not sure if still necessary
     # ./fix_file_read.patch # Unecessary with root v6.30+
     ./roopowerlaw.patch     # Unecessary with root v6.30+, but RooPowerSum not identical so keep it for now
+    ./rookeyspdf.patch
     # Patch below taken from root master (https://github.com/root-project/root/pull/20988), not yet tagged for release as of v6.38
     ./extend_th3_interpolate.patch
   ];

--- a/nix/root/default.nix
+++ b/nix/root/default.nix
@@ -106,6 +106,7 @@ stdenv.mkDerivation rec {
     "-Droot7=OFF"
     "-Dsqlite=OFF"
     "-Dssl=OFF"
+    "-Dunfold=ON"
     "-Dwebgui=OFF"
     "-Dxrootd=OFF"
   ]

--- a/nix/root/default.nix
+++ b/nix/root/default.nix
@@ -44,11 +44,11 @@
 
 stdenv.mkDerivation rec {
   pname = "root";
-  version = "6.24.02";
+  version = "6.32.16";
 
   src = fetchurl {
     url = "https://root.cern.ch/download/root_v${version}.source.tar.gz";
-    sha256 = "0507e1095e279ccc7240f651d25966024325179fa85a1259b694b56723ad7c1c";
+    sha256 = "1b9afc6730aa727722cc60d44a403f7a39b7226086181827bc4cabd0bea4c568";
   };
 
   nativeBuildInputs = [ makeWrapper cmake pkg-config git ];
@@ -62,10 +62,10 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   patches = [
-    ./sw_vers.patch
-    ./hist_factory.patch
-    ./fix_file_read.patch
-    ./roopowerlaw.patch
+    # ./sw_vers.patch       # Not sure if still necessary
+    # ./hist_factory.patch  # Not sure if still necessary
+    # ./fix_file_read.patch # Unecessary with root v6.30+
+    ./roopowerlaw.patch     # Unecessary with root v6.30+, but RooPowerSum not identical so keep it for now
     # Patch below taken from root master (https://github.com/root-project/root/pull/20988), not yet tagged for release as of v6.38
     ./extend_th3_interpolate.patch
   ];
@@ -92,43 +92,21 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [
-    "-Drpath=ON"
     "-DCMAKE_CXX_STANDARD=17"
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
-    "-Dbuiltin_nlohmannjson=OFF"
     "-Dbuiltin_openui5=OFF"
-    "-Dalien=OFF"
-    "-Dbonjour=OFF"
-    "-Dcastor=OFF"
-    "-Dchirp=OFF"
     "-Dclad=OFF"
     "-Ddavix=OFF"
-    "-Ddcache=OFF"
     "-Dfail-on-missing=ON"
     "-Dfftw3=ON"
     "-Dfitsio=OFF"
-    "-Dfortran=OFF"
-    "-Dgfal=OFF"
-    "-Dgviz=OFF"
-    "-Dhdfs=OFF"
-    "-Dhttp=ON"
-    "-Dkrb5=OFF"
-    "-Dldap=OFF"
-    "-Dmonalisa=OFF"
     "-Dmysql=OFF"
-    "-Dodbc=OFF"
-    "-Dopengl=ON"
-    "-Doracle=OFF"
     "-Dpgsql=OFF"
-    "-Dpythia6=OFF"
-    "-Dpythia8=OFF"
-    "-Drfio=OFF"
     "-Droot7=OFF"
     "-Dsqlite=OFF"
     "-Dssl=OFF"
     "-Dwebgui=OFF"
-    "-Dxml=ON"
     "-Dxrootd=OFF"
   ]
   ++ lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${lib.getDev stdenv.cc.libc}/include"

--- a/nix/root/rookeyspdf.patch
+++ b/nix/root/rookeyspdf.patch
@@ -1,0 +1,695 @@
+diff --git a/roofit/roofit/inc/RooKeysPdf.h b/roofit/roofit/inc/RooKeysPdf.h
+index df0e41232e4..9d5c0456e53 100644
+--- a/roofit/roofit/inc/RooKeysPdf.h
++++ b/roofit/roofit/inc/RooKeysPdf.h
+@@ -3,8 +3,9 @@
+  * Package: RooFitModels                                                     *
+  *    File: $Id: RooKeysPdf.h,v 1.10 2007/05/11 09:13:07 verkerke Exp $
+  * Authors:                                                                  *
+- *   GR, Gerhard Raven,   UC San Diego,        raven@slac.stanford.edu       *
+- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 * WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
++ *   GR, Gerhard Raven,   UC San Diego,      raven@slac.stanford.edu         *
++ *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
++ *   WV, Wouter Verkerke, UC Santa Barbara,  verkerke@slac.stanford.edu      *
+  *                                                                           *
+  * Copyright (c) 2000-2005, Regents of the University of California          *
+  *                          and Stanford University. All rights reserved.    *
+@@ -23,61 +24,65 @@ class RooRealVar;
+ 
+ class RooKeysPdf : public RooAbsPdf {
+ public:
+-  enum Mirror { NoMirror, MirrorLeft, MirrorRight, MirrorBoth,
+-      MirrorAsymLeft, MirrorAsymLeftRight,
+-      MirrorAsymRight, MirrorLeftAsymRight,
+-      MirrorAsymBoth };
+-  RooKeysPdf() ;
+-  RooKeysPdf(const char *name, const char *title,
+-             RooAbsReal& x, RooDataSet& data, Mirror mirror= NoMirror,
+-        double rho=1);
+-  RooKeysPdf(const char *name, const char *title,
+-             RooAbsReal& x, RooRealVar& xdata, RooDataSet& data, Mirror mirror= NoMirror,
+-        double rho=1);
+-  RooKeysPdf(const RooKeysPdf& other, const char* name=nullptr);
+-  TObject* clone(const char* newname) const override {return new RooKeysPdf(*this,newname); }
+-  ~RooKeysPdf() override;
++   enum Mirror {
++      NoMirror,
++      MirrorLeft,
++      MirrorRight,
++      MirrorBoth,
++      MirrorAsymLeft,
++      MirrorAsymLeftRight,
++      MirrorAsymRight,
++      MirrorLeftAsymRight,
++      MirrorAsymBoth
++   };
++   RooKeysPdf();
++   RooKeysPdf(const char *name, const char *title, RooAbsReal &x, RooRealVar &x0, RooRealVar &slope, RooRealVar &offset,
++              RooDataSet &data, Mirror mirror = NoMirror, double rho = 1);
++   RooKeysPdf(const char *name, const char *title, RooAbsReal &x, RooRealVar &xdata, RooRealVar &x0, RooRealVar &slope,
++              RooRealVar &offset, RooDataSet &data, Mirror mirror = NoMirror, double rho = 1);
++   RooKeysPdf(const RooKeysPdf &other, const char *name = nullptr);
++   TObject *clone(const char *newname) const override { return new RooKeysPdf(*this, newname); }
++   ~RooKeysPdf() override;
+ 
+-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars,
+-     const char* rangeName = nullptr) const override;
+-  double analyticalIntegral(Int_t code, const char* rangeName = nullptr) const override;
+-  Int_t getMaxVal(const RooArgSet& vars) const override;
+-  double maxVal(Int_t code) const override;
++   Int_t getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char *rangeName = nullptr) const override;
++   double analyticalIntegral(Int_t code, const char *rangeName = nullptr) const override;
+ 
+-  void LoadDataSet( RooDataSet& data);
++   void LoadDataSet(RooDataSet &data);
+ 
+ protected:
+-
+-  RooRealProxy _x ;
+-  double evaluate() const override;
++   RooRealProxy _x;
++   RooRealProxy _x0;
++   RooRealProxy _slope;
++   RooRealProxy _offset;
++   double evaluate() const override;
+ 
+ private:
+-  // how far you have to go out in a Gaussian until it is smaller than the
+-  // machine precision
+-  static const double _nSigma; //!
++   // how far you have to go out in a Gaussian until it is smaller than the
++   // machine precision
++   static const double _nSigma; //!
+ 
+-  Int_t _nEvents = 0;
+-  double *_dataPts = nullptr;  //[_nEvents]
+-  double *_dataWgts = nullptr; //[_nEvents]
+-  double *_weights = nullptr;  //[_nEvents]
+-  double _sumWgt = 0.0;
++   Int_t _nEvents = 0;
++   double *_dataPts = nullptr;  //[_nEvents]
++   double *_dataWgts = nullptr; //[_nEvents]
++   double *_weights = nullptr;  //[_nEvents]
++   double _sumWgt = 0.0;
+ 
+-  constexpr static int _nPoints{1000};
+-  double _lookupTable[_nPoints+1];
++   constexpr static int _nPoints{1000};
++   double _lookupTable[_nPoints + 1];
+ 
+-  double g(double x,double sigma) const;
++   double g(double x, double sigma) const;
+ 
+-  bool _mirrorLeft = false;
+-  bool _mirrorRight = false;
+-  bool _asymLeft = false;
+-  bool _asymRight = false;
++   bool _mirrorLeft = false;
++   bool _mirrorRight = false;
++   bool _asymLeft = false;
++   bool _asymRight = false;
+ 
+-  // cached info on variable
+-  Char_t _varName[128];
+-  double _lo, _hi, _binWidth;
+-  double _rho;
++   // cached info on variable
++   Char_t _varName[128];
++   double _lo, _hi, _binWidth;
++   double _rho;
+ 
+-  ClassDefOverride(RooKeysPdf,2) // One-dimensional non-parametric kernel estimation p.d.f.
++   ClassDefOverride(RooKeysPdf, 2) // One-dimensional non-parametric kernel estimation p.d.f.
+ };
+ 
+ #endif
+diff --git a/roofit/roofit/src/RooKeysPdf.cxx b/roofit/roofit/src/RooKeysPdf.cxx
+index 5361e4b3425..e234c1f19d6 100644
+--- a/roofit/roofit/src/RooKeysPdf.cxx
++++ b/roofit/roofit/src/RooKeysPdf.cxx
+@@ -46,8 +46,7 @@ Cranmer KS, Kernel Estimation in High-Energy Physics.
+ 
+ ClassImp(RooKeysPdf);
+ 
+-const double RooKeysPdf::_nSigma = std::sqrt(-2. *
+-    std::log(std::numeric_limits<double>::epsilon()));
++const double RooKeysPdf::_nSigma = std::sqrt(-2. * std::log(std::numeric_limits<double>::epsilon()));
+ 
+ ////////////////////////////////////////////////////////////////////////////////
+ /// coverity[UNINIT_CTOR]
+@@ -60,18 +59,22 @@ RooKeysPdf::RooKeysPdf()
+ ////////////////////////////////////////////////////////////////////////////////
+ /// cache stuff about x
+ 
+-RooKeysPdf::RooKeysPdf(const char *name, const char *title, RooAbsReal &x, RooDataSet &data, Mirror mirror, double rho)
+-   : RooKeysPdf(name, title, x, static_cast<RooRealVar &>(x), data, mirror, rho)
++RooKeysPdf::RooKeysPdf(const char *name, const char *title, RooAbsReal &x, RooRealVar &x0, RooRealVar &slope,
++                       RooRealVar &offset, RooDataSet &data, Mirror mirror, double rho)
++   : RooKeysPdf(name, title, x, static_cast<RooRealVar &>(x), x0, slope, offset, data, mirror, rho)
+ {
+ }
+ 
+ ////////////////////////////////////////////////////////////////////////////////
+ /// cache stuff about x
+ 
+-RooKeysPdf::RooKeysPdf(const char *name, const char *title, RooAbsReal &xpdf, RooRealVar &xdata, RooDataSet &data,
+-                       Mirror mirror, double rho)
++RooKeysPdf::RooKeysPdf(const char *name, const char *title, RooAbsReal &xpdf, RooRealVar &xdata, RooRealVar &x0,
++                       RooRealVar &slope, RooRealVar &offset, RooDataSet &data, Mirror mirror, double rho)
+    : RooAbsPdf(name, title),
+      _x("x", "Observable", this, xpdf),
++     _x0("x0", "Fixed point", this, x0),
++     _slope("slope", "Slope", this, slope),
++     _offset("offset", "Offset", this, offset),
+      _mirrorLeft(mirror == MirrorLeft || mirror == MirrorBoth || mirror == MirrorLeftAsymRight),
+      _mirrorRight(mirror == MirrorRight || mirror == MirrorBoth || mirror == MirrorAsymLeftRight),
+      _asymLeft(mirror == MirrorAsymLeft || mirror == MirrorAsymLeftRight || mirror == MirrorAsymBoth),
+@@ -81,11 +84,11 @@ RooKeysPdf::RooKeysPdf(const char *name, const char *title, RooAbsReal &xpdf, Ro
+      _binWidth((_hi - _lo) / (_nPoints - 1)),
+      _rho(rho)
+ {
+-  snprintf(_varName, 128,"%s", xdata.GetName());
++   snprintf(_varName, 128, "%s", xdata.GetName());
+ 
+-  // form the lookup table
+-  LoadDataSet(data);
+-  TRACE_CREATE;
++   // form the lookup table
++   LoadDataSet(data);
++   TRACE_CREATE;
+ }
+ 
+ ////////////////////////////////////////////////////////////////////////////////
+@@ -93,6 +96,9 @@ RooKeysPdf::RooKeysPdf(const char *name, const char *title, RooAbsReal &xpdf, Ro
+ RooKeysPdf::RooKeysPdf(const RooKeysPdf &other, const char *name)
+    : RooAbsPdf(other, name),
+      _x("x", this, other._x),
++     _x0("x0", this, other._x0),
++     _slope("slope", this, other._slope),
++     _offset("offset", this, other._offset),
+      _nEvents(other._nEvents),
+      _mirrorLeft(other._mirrorLeft),
+      _mirrorRight(other._mirrorRight),
+@@ -103,279 +109,263 @@ RooKeysPdf::RooKeysPdf(const RooKeysPdf &other, const char *name)
+      _binWidth(other._binWidth),
+      _rho(other._rho)
+ {
+-  // cache stuff about x
+-  snprintf(_varName, 128, "%s", other._varName );
+-
+-  // copy over data and weights... not necessary, commented out for speed
+-//    _dataPts = new double[_nEvents];
+-//    _weights = new double[_nEvents];
+-//    for (Int_t i= 0; i<_nEvents; i++) {
+-//      _dataPts[i]= other._dataPts[i];
+-//      _weights[i]= other._weights[i];
+-//    }
+-
+-  // copy over the lookup table
+-  for (Int_t i= 0; i<_nPoints+1; i++)
+-    _lookupTable[i]= other._lookupTable[i];
+-
+-  TRACE_CREATE;
++   // cache stuff about x
++   snprintf(_varName, 128, "%s", other._varName);
++
++   // copy over data and weights... not necessary, commented out for speed
++   //    _dataPts = new double[_nEvents];
++   //    _weights = new double[_nEvents];
++   //    for (Int_t i= 0; i<_nEvents; i++) {
++   //      _dataPts[i]= other._dataPts[i];
++   //      _weights[i]= other._weights[i];
++   //    }
++
++   // copy over the lookup table
++   for (Int_t i = 0; i < _nPoints + 1; i++)
++      _lookupTable[i] = other._lookupTable[i];
++
++   TRACE_CREATE;
+ }
+ 
+ ////////////////////////////////////////////////////////////////////////////////
+ 
+-RooKeysPdf::~RooKeysPdf() {
+-  delete[] _dataPts;
+-  delete[] _dataWgts;
+-  delete[] _weights;
++RooKeysPdf::~RooKeysPdf()
++{
++   delete[] _dataPts;
++   delete[] _dataWgts;
++   delete[] _weights;
+ 
+-  TRACE_DESTROY;
++   TRACE_DESTROY;
+ }
+ 
+ ////////////////////////////////////////////////////////////////////////////////
+ /// small helper structure
+ 
+ namespace {
+-  struct Data {
+-    double x;
+-    double w;
+-  };
+-  // helper to order two Data structures
+-  struct cmp {
+-    inline bool operator()(const struct Data& a, const struct Data& b) const
+-    { return a.x < b.x; }
+-  };
+-}
+-void RooKeysPdf::LoadDataSet( RooDataSet& data) {
+-  delete[] _dataPts;
+-  delete[] _dataWgts;
+-  delete[] _weights;
+-
+-  std::vector<Data> tmp;
+-  tmp.reserve((1 + _mirrorLeft + _mirrorRight) * data.numEntries());
+-  double x0 = 0.;
+-  double x1 = 0.;
+-  double x2 = 0.;
+-  _sumWgt = 0.;
+-  // read the data set into tmp and accumulate some statistics
+-  RooRealVar& real = static_cast<RooRealVar&>(data.get()->operator[](_varName));
+-  for (Int_t i = 0; i < data.numEntries(); ++i) {
+-    data.get(i);
+-    const double x = real.getVal();
+-    const double w = data.weight();
+-    x0 += w;
+-    x1 += w * x;
+-    x2 += w * x * x;
+-    _sumWgt += double(1 + _mirrorLeft + _mirrorRight) * w;
+-
+-    Data p;
+-    p.x = x, p.w = w;
+-    tmp.push_back(p);
+-    if (_mirrorLeft) {
+-      p.x = 2. * _lo - x;
+-      tmp.push_back(p);
+-    }
+-    if (_mirrorRight) {
+-      p.x = 2. * _hi - x;
++struct Data {
++   double x;
++   double w;
++};
++// helper to order two Data structures
++struct cmp {
++   inline bool operator()(const struct Data &a, const struct Data &b) const { return a.x < b.x; }
++};
++} // namespace
++
++void RooKeysPdf::LoadDataSet(RooDataSet &data)
++{
++   delete[] _dataPts;
++   delete[] _dataWgts;
++   delete[] _weights;
++
++   std::vector<Data> tmp;
++   tmp.reserve((1 + _mirrorLeft + _mirrorRight) * data.numEntries());
++   double x0 = 0.;
++   double x1 = 0.;
++   double x2 = 0.;
++   _sumWgt = 0.;
++   // read the data set into tmp and accumulate some statistics
++   RooRealVar &real = static_cast<RooRealVar &>(data.get()->operator[](_varName));
++   for (Int_t i = 0; i < data.numEntries(); ++i) {
++      data.get(i);
++      const double x = real.getVal();
++      const double w = data.weight();
++      x0 += w;
++      x1 += w * x;
++      x2 += w * x * x;
++      _sumWgt += double(1 + _mirrorLeft + _mirrorRight) * w;
++
++      Data p;
++      p.x = x, p.w = w;
+       tmp.push_back(p);
+-    }
+-  }
+-  // sort the entire data set so that values of x are increasing
+-  std::sort(tmp.begin(), tmp.end(), cmp());
+-
+-  // copy the sorted data set to its final destination
+-  _nEvents = tmp.size();
+-  _dataPts  = new double[_nEvents];
+-  _dataWgts = new double[_nEvents];
+-  for (unsigned i = 0; i < tmp.size(); ++i) {
+-    _dataPts[i] = tmp[i].x;
+-    _dataWgts[i] = tmp[i].w;
+-  }
+-  {
+-    // free tmp
+-    std::vector<Data> tmp2;
+-    tmp2.swap(tmp);
+-  }
+-
+-  double meanv=x1/x0;
+-  double sigmav=std::sqrt(x2/x0-meanv*meanv);
+-  double h=std::pow(double(4)/double(3),0.2)*std::pow(_sumWgt,-0.2)*_rho;
+-  double hmin=h*sigmav*std::sqrt(2.)/10;
+-  double norm=h*std::sqrt(sigmav * _sumWgt)/(2.0*std::sqrt(3.0));
+-
+-  _weights=new double[_nEvents];
+-  for(Int_t j=0;j<_nEvents;++j) {
+-    _weights[j] = norm / std::sqrt(_dataWgts[j] * g(_dataPts[j],h*sigmav));
+-    if (_weights[j]<hmin) _weights[j]=hmin;
+-  }
+-
+-  // The idea below is that beyond nSigma sigma, the value of the exponential
+-  // in the Gaussian is well below the machine precision of a double, so it
+-  // does not contribute any more. That way, we can limit how many bins of the
+-  // binned approximation in _lookupTable we have to touch when filling it.
+-  for (Int_t i=0;i<_nPoints+1;++i) _lookupTable[i] = 0.;
+-  for(Int_t j=0;j<_nEvents;++j) {
+-      const double xlo = std::min(_hi,
+-         std::max(_lo, _dataPts[j] - _nSigma * _weights[j]));
+-      const double xhi = std::max(_lo,
+-         std::min(_hi, _dataPts[j] + _nSigma * _weights[j]));
+-      if (xlo >= xhi) continue;
++      if (_mirrorLeft) {
++         p.x = 2. * _lo - x;
++         tmp.push_back(p);
++      }
++      if (_mirrorRight) {
++         p.x = 2. * _hi - x;
++         tmp.push_back(p);
++      }
++   }
++   // sort the entire data set so that values of x are increasing
++   std::sort(tmp.begin(), tmp.end(), cmp());
++
++   // copy the sorted data set to its final destination
++   _nEvents = tmp.size();
++   _dataPts = new double[_nEvents];
++   _dataWgts = new double[_nEvents];
++   for (unsigned i = 0; i < tmp.size(); ++i) {
++      _dataPts[i] = tmp[i].x;
++      _dataWgts[i] = tmp[i].w;
++   }
++   {
++      // free tmp
++      std::vector<Data> tmp2;
++      tmp2.swap(tmp);
++   }
++
++   double meanv = x1 / x0;
++   double sigmav = std::sqrt(x2 / x0 - meanv * meanv);
++   double h = std::pow(double(4) / double(3), 0.2) * std::pow(_sumWgt, -0.2) * _rho;
++   double hmin = h * sigmav * std::sqrt(2.) / 10;
++   double norm = h * std::sqrt(sigmav * _sumWgt) / (2.0 * std::sqrt(3.0));
++
++   _weights = new double[_nEvents];
++   for (Int_t j = 0; j < _nEvents; ++j) {
++      _weights[j] = norm / std::sqrt(_dataWgts[j] * g(_dataPts[j], h * sigmav));
++      if (_weights[j] < hmin)
++         _weights[j] = hmin;
++   }
++
++   // The idea below is that beyond nSigma sigma, the value of the exponential
++   // in the Gaussian is well below the machine precision of a double, so it
++   // does not contribute any more. That way, we can limit how many bins of the
++   // binned approximation in _lookupTable we have to touch when filling it.
++   for (Int_t i = 0; i < _nPoints + 1; ++i)
++      _lookupTable[i] = 0.;
++
++   for (Int_t j = 0; j < _nEvents; ++j) {
++      const double xlo = std::min(_hi, std::max(_lo, _dataPts[j] - _nSigma * _weights[j]));
++      const double xhi = std::max(_lo, std::min(_hi, _dataPts[j] + _nSigma * _weights[j]));
++      if (xlo >= xhi)
++         continue;
+       const double chi2incr = _binWidth / _weights[j] / std::sqrt(2.);
+       const double weightratio = _dataWgts[j] / _weights[j];
+       const Int_t binlo = static_cast<Int_t>(std::floor((xlo - _lo) / _binWidth));
+       const Int_t binhi = static_cast<Int_t>(_nPoints - std::floor((_hi - xhi) / _binWidth));
+-      const double x = (double(_nPoints - binlo) * _lo +
+-         double(binlo) * _hi) / double(_nPoints);
++      const double x = (double(_nPoints - binlo) * _lo + double(binlo) * _hi) / double(_nPoints);
+       double chi = (x - _dataPts[j]) / _weights[j] / std::sqrt(2.);
+       for (Int_t k = binlo; k <= binhi; ++k, chi += chi2incr) {
+-     _lookupTable[k] += weightratio * std::exp(- chi * chi);
++         _lookupTable[k] += weightratio * std::exp(-chi * chi);
+       }
+-  }
+-  if (_asymLeft) {
+-      for(Int_t j=0;j<_nEvents;++j) {
+-     const double xlo = std::min(_hi,
+-        std::max(_lo, 2. * _lo - _dataPts[j] + _nSigma * _weights[j]));
+-     const double xhi = std::max(_lo,
+-        std::min(_hi, 2. * _lo - _dataPts[j] - _nSigma * _weights[j]));
+-     if (xlo >= xhi) continue;
+-     const double chi2incr = _binWidth / _weights[j] / std::sqrt(2.);
+-     const double weightratio = _dataWgts[j] / _weights[j];
+-     const Int_t binlo = static_cast<Int_t>(std::floor((xlo - _lo) / _binWidth));
+-     const Int_t binhi = static_cast<Int_t>(_nPoints - std::floor((_hi - xhi) / _binWidth));
+-     const double x = (double(_nPoints - binlo) * _lo +
+-        double(binlo) * _hi) / double(_nPoints);
+-     double chi = (x - (2. * _lo - _dataPts[j])) / _weights[j] / std::sqrt(2.);
+-     for (Int_t k = binlo; k <= binhi; ++k, chi += chi2incr) {
+-         _lookupTable[k] -= weightratio * std::exp(- chi * chi);
+-     }
++   }
++   if (_asymLeft) {
++      for (Int_t j = 0; j < _nEvents; ++j) {
++         const double xlo = std::min(_hi, std::max(_lo, 2. * _lo - _dataPts[j] + _nSigma * _weights[j]));
++         const double xhi = std::max(_lo, std::min(_hi, 2. * _lo - _dataPts[j] - _nSigma * _weights[j]));
++         if (xlo >= xhi)
++            continue;
++         const double chi2incr = _binWidth / _weights[j] / std::sqrt(2.);
++         const double weightratio = _dataWgts[j] / _weights[j];
++         const Int_t binlo = static_cast<Int_t>(std::floor((xlo - _lo) / _binWidth));
++         const Int_t binhi = static_cast<Int_t>(_nPoints - std::floor((_hi - xhi) / _binWidth));
++         const double x = (double(_nPoints - binlo) * _lo + double(binlo) * _hi) / double(_nPoints);
++         double chi = (x - (2. * _lo - _dataPts[j])) / _weights[j] / std::sqrt(2.);
++         for (Int_t k = binlo; k <= binhi; ++k, chi += chi2incr) {
++            _lookupTable[k] -= weightratio * std::exp(-chi * chi);
++         }
+       }
+-  }
+-  if (_asymRight) {
+-      for(Int_t j=0;j<_nEvents;++j) {
+-     const double xlo = std::min(_hi,
+-        std::max(_lo, 2. * _hi - _dataPts[j] + _nSigma * _weights[j]));
+-     const double xhi = std::max(_lo,
+-        std::min(_hi, 2. * _hi - _dataPts[j] - _nSigma * _weights[j]));
+-     if (xlo >= xhi) continue;
+-     const double chi2incr = _binWidth / _weights[j] / std::sqrt(2.);
+-     const double weightratio = _dataWgts[j] / _weights[j];
+-     const Int_t binlo = static_cast<Int_t>(std::floor((xlo - _lo) / _binWidth));
+-     const Int_t binhi = static_cast<Int_t>(_nPoints - std::floor((_hi - xhi) / _binWidth));
+-     const double x = (double(_nPoints - binlo) * _lo +
+-        double(binlo) * _hi) / double(_nPoints);
+-     double chi = (x - (2. * _hi - _dataPts[j])) / _weights[j] / std::sqrt(2.);
+-     for (Int_t k = binlo; k <= binhi; ++k, chi += chi2incr) {
+-         _lookupTable[k] -= weightratio * std::exp(- chi * chi);
+-     }
++   }
++   if (_asymRight) {
++      for (Int_t j = 0; j < _nEvents; ++j) {
++         const double xlo = std::min(_hi, std::max(_lo, 2. * _hi - _dataPts[j] + _nSigma * _weights[j]));
++         const double xhi = std::max(_lo, std::min(_hi, 2. * _hi - _dataPts[j] - _nSigma * _weights[j]));
++         if (xlo >= xhi)
++            continue;
++         const double chi2incr = _binWidth / _weights[j] / std::sqrt(2.);
++         const double weightratio = _dataWgts[j] / _weights[j];
++         const Int_t binlo = static_cast<Int_t>(std::floor((xlo - _lo) / _binWidth));
++         const Int_t binhi = static_cast<Int_t>(_nPoints - std::floor((_hi - xhi) / _binWidth));
++         const double x = (double(_nPoints - binlo) * _lo + double(binlo) * _hi) / double(_nPoints);
++         double chi = (x - (2. * _hi - _dataPts[j])) / _weights[j] / std::sqrt(2.);
++         for (Int_t k = binlo; k <= binhi; ++k, chi += chi2incr) {
++            _lookupTable[k] -= weightratio * std::exp(-chi * chi);
++         }
+       }
+-  }
+-  static const double sqrt2pi(std::sqrt(2*TMath::Pi()));
+-  for (Int_t i=0;i<_nPoints+1;++i)
+-    _lookupTable[i] /= sqrt2pi * _sumWgt;
++   }
++   static const double sqrt2pi(std::sqrt(2 * TMath::Pi()));
++   for (Int_t i = 0; i < _nPoints + 1; ++i)
++      _lookupTable[i] /= sqrt2pi * _sumWgt;
+ }
+ 
+ ////////////////////////////////////////////////////////////////////////////////
+ 
+-double RooKeysPdf::evaluate() const {
+-  Int_t i = (Int_t)floor((double(_x)-_lo)/_binWidth);
+-  if (i<0) {
+-//     cerr << "got point below lower bound:"
+-//     << double(_x) << " < " << _lo
+-//     << " -- performing linear extrapolation..." << endl;
+-    i=0;
+-  }
+-  if (i>_nPoints-1) {
+-//     cerr << "got point above upper bound:"
+-//     << double(_x) << " > " << _hi
+-//     << " -- performing linear extrapolation..." << endl;
+-    i=_nPoints-1;
+-  }
+-  double dx = (double(_x)-(_lo+i*_binWidth))/_binWidth;
+-
+-  // for now do simple linear interpolation.
+-  // one day replace by splines...
+-  double ret = (_lookupTable[i]+dx*(_lookupTable[i+1]-_lookupTable[i]));
+-  if (ret<0) ret=0 ;
+-  return ret ;
+-}
+-
+-Int_t RooKeysPdf::getAnalyticalIntegral(
+-   RooArgSet& allVars, RooArgSet& analVars, const char* /* rangeName */) const
++double RooKeysPdf::evaluate() const
+ {
+-  if (matchArgs(allVars, analVars, _x)) return 1;
+-  return 0;
++   const double x = (_x - _x0 - _offset) / _slope + _x0;
++   Int_t i = (Int_t)floor((double(x) - _lo) / _binWidth);
++   if (i < 0) {
++      //     cerr << "got point below lower bound:"
++      //     << double(_x) << " < " << _lo
++      //     << " -- performing linear extrapolation..." << endl;
++      i = 0;
++   }
++   if (i > _nPoints - 1) {
++      //     cerr << "got point above upper bound:"
++      //     << double(_x) << " > " << _hi
++      //     << " -- performing linear extrapolation..." << endl;
++      i = _nPoints - 1;
++   }
++   double dx = (double(x) - (_lo + i * _binWidth)) / _binWidth;
++
++   // for now do simple linear interpolation.
++   // one day replace by splines...
++   double ret = (_lookupTable[i] + dx * (_lookupTable[i + 1] - _lookupTable[i]));
++   if (ret < 0)
++      ret = 0;
++   return ret;
+ }
+ 
+-double RooKeysPdf::analyticalIntegral(Int_t code, const char* rangeName) const
++Int_t RooKeysPdf::getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char * /* rangeName */) const
+ {
+-  R__ASSERT(1 == code);
+-  // this code is based on _lookupTable and uses linear interpolation, just as
+-  // evaluate(); integration is done using the trapez rule
+-  const double xmin = std::max(_lo, _x.min(rangeName));
+-  const double xmax = std::min(_hi, _x.max(rangeName));
+-  const Int_t imin = (Int_t)floor((xmin - _lo) / _binWidth);
+-  const Int_t imax = std::min((Int_t)floor((xmax - _lo) / _binWidth),
+-      _nPoints - 1);
+-  double sum = 0.;
+-  // sum up complete bins in middle
+-  if (imin + 1 < imax)
+-    sum += _lookupTable[imin + 1] + _lookupTable[imax];
+-  for (Int_t i = imin + 2; i < imax; ++i)
+-    sum += 2. * _lookupTable[i];
+-  sum *= _binWidth * 0.5;
+-  // treat incomplete bins
+-  const double dxmin = (xmin - (_lo + imin * _binWidth)) / _binWidth;
+-  const double dxmax = (xmax - (_lo + imax * _binWidth)) / _binWidth;
+-  if (imin < imax) {
+-    // first bin
+-    sum += _binWidth * (1. - dxmin) * 0.5 * (_lookupTable[imin + 1] +
+-   _lookupTable[imin] + dxmin *
+-   (_lookupTable[imin + 1] - _lookupTable[imin]));
+-    // last bin
+-    sum += _binWidth * dxmax * 0.5 * (_lookupTable[imax] +
+-   _lookupTable[imax] + dxmax *
+-   (_lookupTable[imax + 1] - _lookupTable[imax]));
+-  } else if (imin == imax) {
+-    // first bin == last bin
+-    sum += _binWidth * (dxmax - dxmin) * 0.5 * (
+-   _lookupTable[imin] + dxmin *
+-   (_lookupTable[imin + 1] - _lookupTable[imin]) +
+-   _lookupTable[imax] + dxmax *
+-   (_lookupTable[imax + 1] - _lookupTable[imax]));
+-  }
+-  return sum;
++   if (matchArgs(allVars, analVars, _x))
++      return 1;
++   return 0;
+ }
+ 
+-Int_t RooKeysPdf::getMaxVal(const RooArgSet& vars) const
++double RooKeysPdf::analyticalIntegral(Int_t code, const char *rangeName) const
+ {
+-  if (vars.contains(*_x.absArg())) return 1;
+-  return 0;
+-}
+-
+-double RooKeysPdf::maxVal(Int_t code) const
+-{
+-  R__ASSERT(1 == code);
+-  double max = -std::numeric_limits<double>::max();
+-  for (Int_t i = 0; i <= _nPoints; ++i)
+-    if (max < _lookupTable[i]) max = _lookupTable[i];
+-  return max;
++   R__ASSERT(1 == code);
++   // this code is based on _lookupTable and uses linear interpolation, just as
++   // evaluate(); integration is done using the trapez rule
++   const double rmin = (_x.min(rangeName) - _x0 - _offset) / _slope + _x0;
++   const double rmax = (_x.max(rangeName) - _x0 - _offset) / _slope + _x0;
++   const double xmin = std::max(_lo, rmin);
++   const double xmax = std::min(_hi, rmax);
++   const Int_t imin = (Int_t)floor((xmin - _lo) / _binWidth);
++   const Int_t imax = std::min((Int_t)floor((xmax - _lo) / _binWidth), _nPoints - 1);
++   double sum = 0.;
++   // sum up complete bins in middle
++   if (imin + 1 < imax)
++      sum += _lookupTable[imin + 1] + _lookupTable[imax];
++   for (Int_t i = imin + 2; i < imax; ++i)
++      sum += 2. * _lookupTable[i];
++   sum *= _binWidth * 0.5;
++   // treat incomplete bins
++   const double dxmin = (xmin - (_lo + imin * _binWidth)) / _binWidth;
++   const double dxmax = (xmax - (_lo + imax * _binWidth)) / _binWidth;
++   if (imin < imax) {
++      // first bin
++      sum += _binWidth * (1. - dxmin) * 0.5 *
++             (_lookupTable[imin + 1] + _lookupTable[imin] + dxmin * (_lookupTable[imin + 1] - _lookupTable[imin]));
++      // last bin
++      sum += _binWidth * dxmax * 0.5 *
++             (_lookupTable[imax] + _lookupTable[imax] + dxmax * (_lookupTable[imax + 1] - _lookupTable[imax]));
++   } else if (imin == imax) {
++      // first bin == last bin
++      sum += _binWidth * (dxmax - dxmin) * 0.5 *
++             (_lookupTable[imin] + dxmin * (_lookupTable[imin + 1] - _lookupTable[imin]) + _lookupTable[imax] +
++              dxmax * (_lookupTable[imax + 1] - _lookupTable[imax]));
++   }
++   return sum * _slope;
+ }
+ 
+ ////////////////////////////////////////////////////////////////////////////////
+ 
+-double RooKeysPdf::g(double x,double sigmav) const {
+-  double y=0;
+-  // since data is sorted, we can be a little faster because we know which data
+-  // points contribute
+-  double* it = std::lower_bound(_dataPts, _dataPts + _nEvents,
+-      x - _nSigma * sigmav);
+-  if (it >= (_dataPts + _nEvents)) return 0.;
+-  double* iend = std::upper_bound(it, _dataPts + _nEvents,
+-      x + _nSigma * sigmav);
+-  for ( ; it < iend; ++it) {
+-    const double r = (x - *it) / sigmav;
+-    y += std::exp(-0.5 * r * r);
+-  }
+-
+-  static const double sqrt2pi(std::sqrt(2*TMath::Pi()));
+-  return y/(sigmav*sqrt2pi);
++double RooKeysPdf::g(double x, double sigmav) const
++{
++   double y = 0;
++   // since data is sorted, we can be a little faster because we know which data
++   // points contribute
++   double *it = std::lower_bound(_dataPts, _dataPts + _nEvents, x - _nSigma * sigmav);
++   if (it >= (_dataPts + _nEvents))
++      return 0.;
++   double *iend = std::upper_bound(it, _dataPts + _nEvents, x + _nSigma * sigmav);
++   for (; it < iend; ++it) {
++      const double r = (x - *it) / sigmav;
++      y += std::exp(-0.5 * r * r);
++   }
++
++   static const double sqrt2pi(std::sqrt(2 * TMath::Pi()));
++   return y / (sigmav * sqrt2pi);
+ }

--- a/nix/root/rookeyspdf.patch
+++ b/nix/root/rookeyspdf.patch
@@ -1,10 +1,13 @@
 diff --git a/roofit/roofit/inc/RooKeysPdf.h b/roofit/roofit/inc/RooKeysPdf.h
-index df0e41232e4..9d5c0456e53 100644
+index df0e41232e4..a54f5270c15 100644
 --- a/roofit/roofit/inc/RooKeysPdf.h
 +++ b/roofit/roofit/inc/RooKeysPdf.h
-@@ -3,8 +3,9 @@
+@@ -1,10 +1,11 @@
+ /*****************************************************************************
+  * Project: RooFit                                                           *
   * Package: RooFitModels                                                     *
-  *    File: $Id: RooKeysPdf.h,v 1.10 2007/05/11 09:13:07 verkerke Exp $
+- *    File: $Id: RooKeysPdf.h,v 1.10 2007/05/11 09:13:07 verkerke Exp $
++ *    File: $Id: RooKeysPdf.h,v 1.10 2007/05/11 09:13:07 verkerke Exp $      *
   * Authors:                                                                  *
 - *   GR, Gerhard Raven,   UC San Diego,        raven@slac.stanford.edu       *
 - *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 * WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
@@ -14,7 +17,15 @@ index df0e41232e4..9d5c0456e53 100644
   *                                                                           *
   * Copyright (c) 2000-2005, Regents of the University of California          *
   *                          and Stanford University. All rights reserved.    *
-@@ -23,61 +24,65 @@ class RooRealVar;
+@@ -16,6 +17,7 @@
+ #ifndef ROO_KEYS
+ #define ROO_KEYS
+ 
++#include <vector>
+ #include "RooAbsPdf.h"
+ #include "RooRealProxy.h"
+ 
+@@ -23,61 +25,68 @@ class RooRealVar;
  
  class RooKeysPdf : public RooAbsPdf {
  public:
@@ -44,10 +55,11 @@ index df0e41232e4..9d5c0456e53 100644
 +      MirrorAsymBoth
 +   };
 +   RooKeysPdf();
-+   RooKeysPdf(const char *name, const char *title, RooAbsReal &x, RooRealVar &x0, RooRealVar &slope, RooRealVar &offset,
-+              RooDataSet &data, Mirror mirror = NoMirror, double rho = 1);
-+   RooKeysPdf(const char *name, const char *title, RooAbsReal &x, RooRealVar &xdata, RooRealVar &x0, RooRealVar &slope,
-+              RooRealVar &offset, RooDataSet &data, Mirror mirror = NoMirror, double rho = 1);
++   RooKeysPdf(const char *name, const char *title, RooAbsReal &x, RooAbsReal &x0, RooAbsReal &slope, RooAbsReal &offset,
++              RooDataSet &data, Mirror mirror = NoMirror, double rho = 1, bool fast = false, int nPoints = 1000);
++   RooKeysPdf(const char *name, const char *title, RooAbsReal &x, RooRealVar &xdata, RooAbsReal &x0, RooAbsReal &slope,
++              RooAbsReal &offset, RooDataSet &data, Mirror mirror = NoMirror, double rho = 1, bool fast = false,
++              int nPoints = 1000);
 +   RooKeysPdf(const RooKeysPdf &other, const char *name = nullptr);
 +   TObject *clone(const char *newname) const override { return new RooKeysPdf(*this, newname); }
 +   ~RooKeysPdf() override;
@@ -79,7 +91,7 @@ index df0e41232e4..9d5c0456e53 100644
 -  static const double _nSigma; //!
 +   // how far you have to go out in a Gaussian until it is smaller than the
 +   // machine precision
-+   static const double _nSigma; //!
++   const double _nSigma = std::sqrt(-2. * std::log(std::numeric_limits<double>::epsilon()));
  
 -  Int_t _nEvents = 0;
 -  double *_dataPts = nullptr;  //[_nEvents]
@@ -94,20 +106,21 @@ index df0e41232e4..9d5c0456e53 100644
  
 -  constexpr static int _nPoints{1000};
 -  double _lookupTable[_nPoints+1];
-+   constexpr static int _nPoints{1000};
-+   double _lookupTable[_nPoints + 1];
++   int _nPoints;
++   std::vector<double> _lookupTable;
  
 -  double g(double x,double sigma) const;
 +   double g(double x, double sigma) const;
++   double interpolate_table(const double &x, const std::vector<double> &table) const;
  
 -  bool _mirrorLeft = false;
 -  bool _mirrorRight = false;
 -  bool _asymLeft = false;
 -  bool _asymRight = false;
-+   bool _mirrorLeft = false;
-+   bool _mirrorRight = false;
-+   bool _asymLeft = false;
-+   bool _asymRight = false;
++   bool _mirrorLeft;
++   bool _mirrorRight;
++   bool _asymLeft;
++   bool _asymRight;
  
 -  // cached info on variable
 -  Char_t _varName[128];
@@ -117,6 +130,7 @@ index df0e41232e4..9d5c0456e53 100644
 +   Char_t _varName[128];
 +   double _lo, _hi, _binWidth;
 +   double _rho;
++   bool _fast;
  
 -  ClassDefOverride(RooKeysPdf,2) // One-dimensional non-parametric kernel estimation p.d.f.
 +   ClassDefOverride(RooKeysPdf, 2) // One-dimensional non-parametric kernel estimation p.d.f.
@@ -124,28 +138,46 @@ index df0e41232e4..9d5c0456e53 100644
  
  #endif
 diff --git a/roofit/roofit/src/RooKeysPdf.cxx b/roofit/roofit/src/RooKeysPdf.cxx
-index 5361e4b3425..e234c1f19d6 100644
+index 5361e4b3425..84187b8cf13 100644
 --- a/roofit/roofit/src/RooKeysPdf.cxx
 +++ b/roofit/roofit/src/RooKeysPdf.cxx
-@@ -46,8 +46,7 @@ Cranmer KS, Kernel Estimation in High-Energy Physics.
+@@ -1,7 +1,7 @@
+ /*****************************************************************************
+  * Project: RooFit                                                           *
+  * Package: RooFitModels                                                     *
+- * @(#)root/roofit:$Id$
++ * @(#)root/roofit:$Id$                                                      *
+  * Authors:                                                                  *
+  *   GR, Gerhard Raven,   UC San Diego,        raven@slac.stanford.edu       *
+  *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
+@@ -21,7 +21,7 @@
+ Class RooKeysPdf implements a one-dimensional kernel estimation p.d.f which model the distribution
+ of an arbitrary input dataset as a superposition of Gaussian kernels, one for each data point,
+ each contributing 1/N to the total integral of the pdf.
+-If the 'adaptive mode' is enabled, the width of the Gaussian is adaptively calculated from the
++The width of the Gaussian is adaptively calculated from the
+ local density of events, i.e. narrow for regions with high event density to preserve details and
+ wide for regions with low event density to promote smoothness. The details of the general algorithm
+ are described in the following paper:
+@@ -46,9 +46,6 @@ Cranmer KS, Kernel Estimation in High-Energy Physics.
  
  ClassImp(RooKeysPdf);
  
 -const double RooKeysPdf::_nSigma = std::sqrt(-2. *
 -    std::log(std::numeric_limits<double>::epsilon()));
-+const double RooKeysPdf::_nSigma = std::sqrt(-2. * std::log(std::numeric_limits<double>::epsilon()));
- 
+-
  ////////////////////////////////////////////////////////////////////////////////
  /// coverity[UNINIT_CTOR]
-@@ -60,18 +59,22 @@ RooKeysPdf::RooKeysPdf()
+ 
+@@ -60,18 +57,25 @@ RooKeysPdf::RooKeysPdf()
  ////////////////////////////////////////////////////////////////////////////////
  /// cache stuff about x
  
 -RooKeysPdf::RooKeysPdf(const char *name, const char *title, RooAbsReal &x, RooDataSet &data, Mirror mirror, double rho)
 -   : RooKeysPdf(name, title, x, static_cast<RooRealVar &>(x), data, mirror, rho)
-+RooKeysPdf::RooKeysPdf(const char *name, const char *title, RooAbsReal &x, RooRealVar &x0, RooRealVar &slope,
-+                       RooRealVar &offset, RooDataSet &data, Mirror mirror, double rho)
-+   : RooKeysPdf(name, title, x, static_cast<RooRealVar &>(x), x0, slope, offset, data, mirror, rho)
++RooKeysPdf::RooKeysPdf(const char *name, const char *title, RooAbsReal &x, RooAbsReal &x0, RooAbsReal &slope,
++                       RooAbsReal &offset, RooDataSet &data, Mirror mirror, double rho, bool fast, int nPoints)
++   : RooKeysPdf(name, title, x, static_cast<RooRealVar &>(x), x0, slope, offset, data, mirror, rho, fast, nPoints)
  {
  }
  
@@ -154,19 +186,26 @@ index 5361e4b3425..e234c1f19d6 100644
  
 -RooKeysPdf::RooKeysPdf(const char *name, const char *title, RooAbsReal &xpdf, RooRealVar &xdata, RooDataSet &data,
 -                       Mirror mirror, double rho)
-+RooKeysPdf::RooKeysPdf(const char *name, const char *title, RooAbsReal &xpdf, RooRealVar &xdata, RooRealVar &x0,
-+                       RooRealVar &slope, RooRealVar &offset, RooDataSet &data, Mirror mirror, double rho)
++RooKeysPdf::RooKeysPdf(const char *name, const char *title, RooAbsReal &xpdf, RooRealVar &xdata, RooAbsReal &x0,
++                       RooAbsReal &slope, RooAbsReal &offset, RooDataSet &data, Mirror mirror, double rho, bool fast,
++                       int nPoints)
     : RooAbsPdf(name, title),
       _x("x", "Observable", this, xpdf),
 +     _x0("x0", "Fixed point", this, x0),
 +     _slope("slope", "Slope", this, slope),
 +     _offset("offset", "Offset", this, offset),
++     _nPoints(nPoints),
++     _lookupTable(_nPoints + 1, 0.),
       _mirrorLeft(mirror == MirrorLeft || mirror == MirrorBoth || mirror == MirrorLeftAsymRight),
       _mirrorRight(mirror == MirrorRight || mirror == MirrorBoth || mirror == MirrorAsymLeftRight),
       _asymLeft(mirror == MirrorAsymLeft || mirror == MirrorAsymLeftRight || mirror == MirrorAsymBoth),
-@@ -81,11 +84,11 @@ RooKeysPdf::RooKeysPdf(const char *name, const char *title, RooAbsReal &xpdf, Ro
+@@ -79,13 +83,14 @@ RooKeysPdf::RooKeysPdf(const char *name, const char *title, RooAbsReal &xpdf, Ro
+      _lo(xdata.getMin()),
+      _hi(xdata.getMax()),
       _binWidth((_hi - _lo) / (_nPoints - 1)),
-      _rho(rho)
+-     _rho(rho)
++     _rho(rho),
++     _fast(fast)
  {
 -  snprintf(_varName, 128,"%s", xdata.GetName());
 +   snprintf(_varName, 128, "%s", xdata.GetName());
@@ -180,7 +219,7 @@ index 5361e4b3425..e234c1f19d6 100644
  }
  
  ////////////////////////////////////////////////////////////////////////////////
-@@ -93,6 +96,9 @@ RooKeysPdf::RooKeysPdf(const char *name, const char *title, RooAbsReal &xpdf, Ro
+@@ -93,7 +98,12 @@ RooKeysPdf::RooKeysPdf(const char *name, const char *title, RooAbsReal &xpdf, Ro
  RooKeysPdf::RooKeysPdf(const RooKeysPdf &other, const char *name)
     : RooAbsPdf(other, name),
       _x("x", this, other._x),
@@ -188,11 +227,18 @@ index 5361e4b3425..e234c1f19d6 100644
 +     _slope("slope", this, other._slope),
 +     _offset("offset", this, other._offset),
       _nEvents(other._nEvents),
++     _nPoints(other._nPoints),
++     _lookupTable(_nPoints + 1, 0.),
       _mirrorLeft(other._mirrorLeft),
       _mirrorRight(other._mirrorRight),
-@@ -103,279 +109,263 @@ RooKeysPdf::RooKeysPdf(const RooKeysPdf &other, const char *name)
+      _asymLeft(other._asymLeft),
+@@ -101,281 +111,328 @@ RooKeysPdf::RooKeysPdf(const RooKeysPdf &other, const char *name)
+      _lo(other._lo),
+      _hi(other._hi),
       _binWidth(other._binWidth),
-      _rho(other._rho)
+-     _rho(other._rho)
++     _rho(other._rho),
++     _fast(other._fast)
  {
 -  // cache stuff about x
 -  snprintf(_varName, 128, "%s", other._varName );
@@ -367,6 +413,7 @@ index 5361e4b3425..e234c1f19d6 100644
 -      const double xhi = std::max(_lo,
 -         std::min(_hi, _dataPts[j] + _nSigma * _weights[j]));
 -      if (xlo >= xhi) continue;
+-      const double chi2incr = _binWidth / _weights[j] / std::sqrt(2.);
 +      if (_mirrorLeft) {
 +         p.x = 2. * _lo - x;
 +         tmp.push_back(p);
@@ -393,15 +440,84 @@ index 5361e4b3425..e234c1f19d6 100644
 +      tmp2.swap(tmp);
 +   }
 +
++   const double sqrt2 = std::sqrt(2.);
++   const double sqrt2pi = std::sqrt(2. * TMath::Pi());
++
 +   double meanv = x1 / x0;
 +   double sigmav = std::sqrt(x2 / x0 - meanv * meanv);
-+   double h = std::pow(double(4) / double(3), 0.2) * std::pow(_sumWgt, -0.2) * _rho;
-+   double hmin = h * sigmav * std::sqrt(2.) / 10;
++   double h = std::pow(4. / 3., 0.2) * std::pow(_sumWgt, -0.2) * _rho;
++   double hmin = h * sigmav * sqrt2 / 10;
 +   double norm = h * std::sqrt(sigmav * _sumWgt) / (2.0 * std::sqrt(3.0));
++
++   // NOTE There are two differences with respect to the paper:
++   // 1) rho is already included in the h_star definition, so it also affects f0
++   // 2) h_i is further scaled by a factor 2*sqrt(3).
++
++   // Build lookup table for f0 if requested
++   std::vector<double> _lookupTable_f0;
++   if (_fast) {
++      _lookupTable_f0 = std::move(std::vector<double>(_nPoints + 1, 0.));
++      const double h_star = h * sigmav;
++      const double chi2incr = _binWidth / (h_star * sqrt2);
++      for (Int_t j = 0; j < _nEvents; ++j) {
++         const double xlo = std::min(_hi, std::max(_lo, _dataPts[j] - _nSigma * h_star));
++         const double xhi = std::max(_lo, std::min(_hi, _dataPts[j] + _nSigma * h_star));
++         if (xlo >= xhi)
++            continue;
++         const double weightratio = _dataWgts[j] / h_star;
++         const Int_t binlo = static_cast<Int_t>(std::floor((xlo - _lo) / _binWidth));
++         const Int_t binhi = static_cast<Int_t>(_nPoints - std::floor((_hi - xhi) / _binWidth));
++         const double x = (double(_nPoints - binlo) * _lo + double(binlo) * _hi) / double(_nPoints);
++         double chi = (x - _dataPts[j]) / (h_star * sqrt2);
++         for (Int_t k = binlo; k <= binhi; ++k, chi += chi2incr) {
++            _lookupTable_f0[k] += weightratio * std::exp(-chi * chi);
++         }
++      }
++      if (_asymLeft) {
++         for (Int_t j = 0; j < _nEvents; ++j) {
++            const double xlo = std::min(_hi, std::max(_lo, 2. * _lo - _dataPts[j] + _nSigma * h_star));
++            const double xhi = std::max(_lo, std::min(_hi, 2. * _lo - _dataPts[j] - _nSigma * h_star));
++            if (xlo >= xhi)
++               continue;
++            const double weightratio = _dataWgts[j] / h_star;
++            const Int_t binlo = static_cast<Int_t>(std::floor((xlo - _lo) / _binWidth));
++            const Int_t binhi = static_cast<Int_t>(_nPoints - std::floor((_hi - xhi) / _binWidth));
++            const double x = (double(_nPoints - binlo) * _lo + double(binlo) * _hi) / double(_nPoints);
++            double chi = (x - (2. * _lo - _dataPts[j])) / (h_star * sqrt2);
++            for (Int_t k = binlo; k <= binhi; ++k, chi += chi2incr) {
++               _lookupTable_f0[k] -= weightratio * std::exp(-chi * chi);
++            }
++         }
++      }
++      if (_asymRight) {
++         for (Int_t j = 0; j < _nEvents; ++j) {
++            const double xlo = std::min(_hi, std::max(_lo, 2. * _hi - _dataPts[j] + _nSigma * h_star));
++            const double xhi = std::max(_lo, std::min(_hi, 2. * _hi - _dataPts[j] - _nSigma * h_star));
++            if (xlo >= xhi)
++               continue;
++            const double weightratio = _dataWgts[j] / h_star;
++            const Int_t binlo = static_cast<Int_t>(std::floor((xlo - _lo) / _binWidth));
++            const Int_t binhi = static_cast<Int_t>(_nPoints - std::floor((_hi - xhi) / _binWidth));
++            const double x = (double(_nPoints - binlo) * _lo + double(binlo) * _hi) / double(_nPoints);
++            double chi = (x - (2. * _hi - _dataPts[j])) / (h_star * sqrt2);
++            for (Int_t k = binlo; k <= binhi; ++k, chi += chi2incr) {
++               _lookupTable_f0[k] -= weightratio * std::exp(-chi * chi);
++            }
++         }
++      }
++
++      // To match the output of g(), the lookup table for f0 does not include the global 1/n factor.
++      for (Int_t i = 0; i < _nPoints + 1; ++i)
++         _lookupTable_f0[i] /= sqrt2pi;
++   }
++
++   // if fast, use table; If not, use g.
 +
 +   _weights = new double[_nEvents];
 +   for (Int_t j = 0; j < _nEvents; ++j) {
-+      _weights[j] = norm / std::sqrt(_dataWgts[j] * g(_dataPts[j], h * sigmav));
++      // f0 here does not include the global 1/n factor
++      const double f0 = _fast ? interpolate_table(_dataPts[j], _lookupTable_f0) : g(_dataPts[j], h * sigmav);
++      _weights[j] = norm / std::sqrt(_dataWgts[j] * f0);
 +      if (_weights[j] < hmin)
 +         _weights[j] = hmin;
 +   }
@@ -410,22 +526,20 @@ index 5361e4b3425..e234c1f19d6 100644
 +   // in the Gaussian is well below the machine precision of a double, so it
 +   // does not contribute any more. That way, we can limit how many bins of the
 +   // binned approximation in _lookupTable we have to touch when filling it.
-+   for (Int_t i = 0; i < _nPoints + 1; ++i)
-+      _lookupTable[i] = 0.;
-+
 +   for (Int_t j = 0; j < _nEvents; ++j) {
 +      const double xlo = std::min(_hi, std::max(_lo, _dataPts[j] - _nSigma * _weights[j]));
 +      const double xhi = std::max(_lo, std::min(_hi, _dataPts[j] + _nSigma * _weights[j]));
 +      if (xlo >= xhi)
 +         continue;
-       const double chi2incr = _binWidth / _weights[j] / std::sqrt(2.);
++      const double chi2incr = _binWidth / (_weights[j] * sqrt2);
        const double weightratio = _dataWgts[j] / _weights[j];
        const Int_t binlo = static_cast<Int_t>(std::floor((xlo - _lo) / _binWidth));
        const Int_t binhi = static_cast<Int_t>(_nPoints - std::floor((_hi - xhi) / _binWidth));
 -      const double x = (double(_nPoints - binlo) * _lo +
 -         double(binlo) * _hi) / double(_nPoints);
+-      double chi = (x - _dataPts[j]) / _weights[j] / std::sqrt(2.);
 +      const double x = (double(_nPoints - binlo) * _lo + double(binlo) * _hi) / double(_nPoints);
-       double chi = (x - _dataPts[j]) / _weights[j] / std::sqrt(2.);
++      double chi = (x - _dataPts[j]) / (_weights[j] * sqrt2);
        for (Int_t k = binlo; k <= binhi; ++k, chi += chi2incr) {
 -     _lookupTable[k] += weightratio * std::exp(- chi * chi);
 +         _lookupTable[k] += weightratio * std::exp(-chi * chi);
@@ -455,12 +569,12 @@ index 5361e4b3425..e234c1f19d6 100644
 +         const double xhi = std::max(_lo, std::min(_hi, 2. * _lo - _dataPts[j] - _nSigma * _weights[j]));
 +         if (xlo >= xhi)
 +            continue;
-+         const double chi2incr = _binWidth / _weights[j] / std::sqrt(2.);
++         const double chi2incr = _binWidth / (_weights[j] * sqrt2);
 +         const double weightratio = _dataWgts[j] / _weights[j];
 +         const Int_t binlo = static_cast<Int_t>(std::floor((xlo - _lo) / _binWidth));
 +         const Int_t binhi = static_cast<Int_t>(_nPoints - std::floor((_hi - xhi) / _binWidth));
 +         const double x = (double(_nPoints - binlo) * _lo + double(binlo) * _hi) / double(_nPoints);
-+         double chi = (x - (2. * _lo - _dataPts[j])) / _weights[j] / std::sqrt(2.);
++         double chi = (x - (2. * _lo - _dataPts[j])) / (_weights[j] * sqrt2);
 +         for (Int_t k = binlo; k <= binhi; ++k, chi += chi2incr) {
 +            _lookupTable[k] -= weightratio * std::exp(-chi * chi);
 +         }
@@ -490,12 +604,12 @@ index 5361e4b3425..e234c1f19d6 100644
 +         const double xhi = std::max(_lo, std::min(_hi, 2. * _hi - _dataPts[j] - _nSigma * _weights[j]));
 +         if (xlo >= xhi)
 +            continue;
-+         const double chi2incr = _binWidth / _weights[j] / std::sqrt(2.);
++         const double chi2incr = _binWidth / (_weights[j] * sqrt2);
 +         const double weightratio = _dataWgts[j] / _weights[j];
 +         const Int_t binlo = static_cast<Int_t>(std::floor((xlo - _lo) / _binWidth));
 +         const Int_t binhi = static_cast<Int_t>(_nPoints - std::floor((_hi - xhi) / _binWidth));
 +         const double x = (double(_nPoints - binlo) * _lo + double(binlo) * _hi) / double(_nPoints);
-+         double chi = (x - (2. * _hi - _dataPts[j])) / _weights[j] / std::sqrt(2.);
++         double chi = (x - (2. * _hi - _dataPts[j])) / (_weights[j] * sqrt2);
 +         for (Int_t k = binlo; k <= binhi; ++k, chi += chi2incr) {
 +            _lookupTable[k] -= weightratio * std::exp(-chi * chi);
 +         }
@@ -505,7 +619,7 @@ index 5361e4b3425..e234c1f19d6 100644
 -  for (Int_t i=0;i<_nPoints+1;++i)
 -    _lookupTable[i] /= sqrt2pi * _sumWgt;
 +   }
-+   static const double sqrt2pi(std::sqrt(2 * TMath::Pi()));
++
 +   for (Int_t i = 0; i < _nPoints + 1; ++i)
 +      _lookupTable[i] /= sqrt2pi * _sumWgt;
  }
@@ -537,36 +651,23 @@ index 5361e4b3425..e234c1f19d6 100644
 -
 -Int_t RooKeysPdf::getAnalyticalIntegral(
 -   RooArgSet& allVars, RooArgSet& analVars, const char* /* rangeName */) const
-+double RooKeysPdf::evaluate() const
++double RooKeysPdf::interpolate_table(const double &x, const std::vector<double> &table) const
  {
 -  if (matchArgs(allVars, analVars, _x)) return 1;
 -  return 0;
-+   const double x = (_x - _x0 - _offset) / _slope + _x0;
-+   Int_t i = (Int_t)floor((double(x) - _lo) / _binWidth);
++   Int_t i = (Int_t)floor((x - _lo) / _binWidth);
 +   if (i < 0) {
-+      //     cerr << "got point below lower bound:"
-+      //     << double(_x) << " < " << _lo
-+      //     << " -- performing linear extrapolation..." << endl;
 +      i = 0;
 +   }
 +   if (i > _nPoints - 1) {
-+      //     cerr << "got point above upper bound:"
-+      //     << double(_x) << " > " << _hi
-+      //     << " -- performing linear extrapolation..." << endl;
 +      i = _nPoints - 1;
 +   }
-+   double dx = (double(x) - (_lo + i * _binWidth)) / _binWidth;
-+
-+   // for now do simple linear interpolation.
-+   // one day replace by splines...
-+   double ret = (_lookupTable[i] + dx * (_lookupTable[i + 1] - _lookupTable[i]));
-+   if (ret < 0)
-+      ret = 0;
-+   return ret;
++   const double dx = (x - (_lo + i * _binWidth)) / _binWidth;
++   return table[i] + dx * (table[i + 1] - table[i]);
  }
  
 -double RooKeysPdf::analyticalIntegral(Int_t code, const char* rangeName) const
-+Int_t RooKeysPdf::getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char * /* rangeName */) const
++double RooKeysPdf::evaluate() const
  {
 -  R__ASSERT(1 == code);
 -  // this code is based on _lookupTable and uses linear interpolation, just as
@@ -604,20 +705,26 @@ index 5361e4b3425..e234c1f19d6 100644
 -   (_lookupTable[imax + 1] - _lookupTable[imax]));
 -  }
 -  return sum;
++   const double x = (_x - _x0 - _offset) / _slope + _x0;
++   double ret = interpolate_table(x, _lookupTable);
++   if (ret < 0)
++      ret = 0;
++   return ret;
+ }
+ 
+-Int_t RooKeysPdf::getMaxVal(const RooArgSet& vars) const
++Int_t RooKeysPdf::getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char * /* rangeName */) const
+ {
+-  if (vars.contains(*_x.absArg())) return 1;
+-  return 0;
 +   if (matchArgs(allVars, analVars, _x))
 +      return 1;
 +   return 0;
  }
  
--Int_t RooKeysPdf::getMaxVal(const RooArgSet& vars) const
+-double RooKeysPdf::maxVal(Int_t code) const
 +double RooKeysPdf::analyticalIntegral(Int_t code, const char *rangeName) const
  {
--  if (vars.contains(*_x.absArg())) return 1;
--  return 0;
--}
--
--double RooKeysPdf::maxVal(Int_t code) const
--{
 -  R__ASSERT(1 == code);
 -  double max = -std::numeric_limits<double>::max();
 -  for (Int_t i = 0; i <= _nPoints; ++i)

--- a/nix/root/roopowerlaw.patch
+++ b/nix/root/roopowerlaw.patch
@@ -130,7 +130,7 @@ index 00000000000..f249f68b29f
 +#endif
 diff --git a/roofit/roofit/src/RooPowerLaw.cxx b/roofit/roofit/src/RooPowerLaw.cxx
 new file mode 100644
-index 00000000000..590ee619f79
+index 00000000000..e321697e988
 --- /dev/null
 +++ b/roofit/roofit/src/RooPowerLaw.cxx
 @@ -0,0 +1,113 @@
@@ -202,11 +202,11 @@ index 00000000000..590ee619f79
 +}
 +
 +////////////////////////////////////////////////////////////////////////////////
-+/// Compute multiple values of Exponential distribution.
++/// Compute multiple values of PowerLaw distribution.
 +void RooPowerLaw::doEval(RooFit::EvalContext &ctx) const
 +{
-+   auto computer = RooBatchCompute::Exponential;
-+   RooBatchCompute::compute(ctx.config(this), computer, ctx.output(), {ctx.at(x), ctx.at(c)});
++   auto computer = RooBatchCompute::PowerLaw;
++   RooBatchCompute::compute(ctx.config(this), computer, ctx.output(), {ctx.at(x), ctx.at(x0), ctx.at(c)});
 +}
 +
 +////////////////////////////////////////////////////////////////////////////////

--- a/nix/root/roopowerlaw.patch
+++ b/nix/root/roopowerlaw.patch
@@ -1,73 +1,69 @@
-diff --git a/roofit/batchcompute/inc/RooBatchCompute.h b/roofit/batchcompute/inc/RooBatchCompute.h
-index da3dd9c8e0..0a81c98153 100644
---- a/roofit/batchcompute/inc/RooBatchCompute.h
-+++ b/roofit/batchcompute/inc/RooBatchCompute.h
-@@ -55,6 +55,7 @@ namespace RooBatchCompute {
-     virtual RooSpan<double> computeNovosibirsk(const RooAbsReal*, RunContext&, RooSpan<const double> x, RooSpan<const double> peak, RooSpan<const double> width, RooSpan<const double> tail) = 0;
-     virtual RooSpan<double> computePoisson(const RooAbsReal*, RunContext&, RooSpan<const double> x, RooSpan<const double> mean, bool protectNegative, bool noRounding) = 0;
-     virtual void computePolynomial(size_t batchSize, double * __restrict output, const double * __restrict const xData, int lowestOrder, std::vector<BracketAdapterWithMask> &coef) = 0;
-+    virtual RooSpan<double> computePowerLaw(const RooAbsReal*, RunContext&, RooSpan<const double> x, RooSpan<const double> x0, RooSpan<const double> c) = 0;
-     virtual RooSpan<double> computeVoigtian(const RooAbsReal*, RunContext&, RooSpan<const double> x, RooSpan<const double> mean, RooSpan<const double> width, RooSpan<const double> sigma) = 0;
-   };
-
-diff --git a/roofit/batchcompute/src/RooBatchCompute.cxx b/roofit/batchcompute/src/RooBatchCompute.cxx
-index 04d8637533..f58a7ecb1b 100644
---- a/roofit/batchcompute/src/RooBatchCompute.cxx
-+++ b/roofit/batchcompute/src/RooBatchCompute.cxx
-@@ -614,6 +614,18 @@ namespace RooBatchCompute {
-       }
-     }
-
-+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+diff --git a/roofit/batchcompute/res/RooBatchCompute.h b/roofit/batchcompute/res/RooBatchCompute.h
+index 7b79907d5ce..a6431c0d066 100644
+--- a/roofit/batchcompute/res/RooBatchCompute.h
++++ b/roofit/batchcompute/res/RooBatchCompute.h
+@@ -94,6 +94,7 @@ enum Computer {
+    Poisson,
+    Polynomial,
+    Power,
++   PowerLaw,
+    ProdPdf,
+    Ratio,
+    TruthModelExpBasis,
+diff --git a/roofit/batchcompute/src/ComputeFunctions.cxx b/roofit/batchcompute/src/ComputeFunctions.cxx
+index 78e8ca3a7d2..2045605d3dc 100644
+--- a/roofit/batchcompute/src/ComputeFunctions.cxx
++++ b/roofit/batchcompute/src/ComputeFunctions.cxx
+@@ -766,6 +766,16 @@ __rooglobal__ void computePower(Batches &batches)
+    }
+ }
+ 
++__rooglobal__ void computePowerLaw(Batches &batches)
++{
++   Batch x = batches.args[0];
++   Batch x0 = batches.args[1];
++   Batch c = batches.args[2];
++   for (size_t i = BEGIN; i < batches.nEvents; i += STEP) {
++      batches.output[i] = (x[i] > x0[i]) ? std::pow(x[i] - x0[i], c[i]) : 0.;
++   }
++}
 +
-+    struct PowerLawComputer {
-+      template<class Tx, class Tx0, class Tc>
-+      void run(size_t n, double* __restrict output, Tx x, Tx0 x0, Tc c) const
-+      {
-+        for (size_t i = 0; i < n; ++i) {
-+          output[i] = std::pow(x[i]-x0[i], c[i]);
-+        }
-+      }
-+    };
-+
- //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-     struct VoigtianComputer {
-@@ -754,6 +766,9 @@ namespace RooBatchCompute {
-         void computePolynomial(size_t batchSize, double* __restrict output, const double* __restrict const X, int lowestOrder, std::vector<BracketAdapterWithMask>& coefList)  override {
-           startComputationPolynomial(batchSize, output, X, lowestOrder, coefList);
-         }
-+        RooSpan<double> computePowerLaw(const RooAbsReal* caller, RunContext& evalData, RooSpan<const double> x, RooSpan<const double> x0, RooSpan<const double> c)  override {
-+          return startComputation(caller, evalData, PowerLawComputer{}, x, x0, c);
-+        }
-         RooSpan<double> computeVoigtian(const RooAbsReal* caller, RunContext& evalData, RooSpan<const double> x, RooSpan<const double> mean, RooSpan<const double> width, RooSpan<const double> sigma)  override {
-           return startComputation(caller, evalData, VoigtianComputer{}, x, mean, width, sigma);
-         }
+ __rooglobal__ void computeProdPdf(Batches &batches)
+ {
+    const int nPdfs = batches.extra[0];
+@@ -949,6 +959,7 @@ std::vector<void (*)(Batches &)> getFunctions()
+            computePoisson,
+            computePolynomial,
+            computePower,
++           computePowerLaw,
+            computeProdPdf,
+            computeRatio,
+            computeTruthModelExpBasis,
 diff --git a/roofit/roofit/CMakeLists.txt b/roofit/roofit/CMakeLists.txt
-index ec00c119f8..2b1d1f6de8 100644
+index 0e653a47a85..8213aedbb32 100644
 --- a/roofit/roofit/CMakeLists.txt
 +++ b/roofit/roofit/CMakeLists.txt
-@@ -60,6 +60,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFit
+@@ -66,6 +66,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFit
      RooParamHistFunc.h
      RooPoisson.h
      RooPolynomial.h
 +    RooPowerLaw.h
+     RooSpline.h
      RooStepFunction.h
      RooTFnBinding.h
-     RooTFnPdfBinding.h
-@@ -120,6 +121,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFit
+@@ -129,6 +130,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFit
      src/RooParamHistFunc.cxx
      src/RooPoisson.cxx
      src/RooPolynomial.cxx
 +    src/RooPowerLaw.cxx
+     src/RooSpline.cxx
      src/RooStepFunction.cxx
      src/RooTFnBinding.cxx
-     src/RooTFnPdfBinding.cxx
 diff --git a/roofit/roofit/inc/LinkDef1.h b/roofit/roofit/inc/LinkDef1.h
-index 77c410765c..3971d56f9b 100644
+index 06d3fb51d93..10cb1dd6186 100644
 --- a/roofit/roofit/inc/LinkDef1.h
 +++ b/roofit/roofit/inc/LinkDef1.h
-@@ -33,6 +33,7 @@
+@@ -35,6 +35,7 @@
  #pragma link C++ class RooParamHistFunc+ ;
  #pragma link C++ class RooParametricStepFunction+ ;
  #pragma link C++ class RooPolynomial+ ;
@@ -77,17 +73,13 @@ index 77c410765c..3971d56f9b 100644
  #pragma link C++ class RooUnblindPrecision+ ;
 diff --git a/roofit/roofit/inc/RooPowerLaw.h b/roofit/roofit/inc/RooPowerLaw.h
 new file mode 100644
-index 0000000000..6837529f52
+index 00000000000..f249f68b29f
 --- /dev/null
 +++ b/roofit/roofit/inc/RooPowerLaw.h
-@@ -0,0 +1,49 @@
+@@ -0,0 +1,51 @@
 +/*****************************************************************************
 + * Project: RooFit                                                           *
 + * Package: RooFitModels                                                     *
-+ *    File: $Id: RooPowerLaw.h,v 1.10 2007/07/12 20:30:49 wouter Exp $
-+ * Authors:                                                                  *
-+ *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
-+ *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
 + *                                                                           *
 + * Copyright (c) 2000-2005, Regents of the University of California          *
 + *                          and Stanford University. All rights reserved.    *
@@ -102,37 +94,43 @@ index 0000000000..6837529f52
 +#include "RooAbsPdf.h"
 +#include "RooRealProxy.h"
 +
-+class RooRealVar;
-+class RooAbsReal;
-+
 +class RooPowerLaw : public RooAbsPdf {
 +public:
 +  RooPowerLaw() {} ;
 +  RooPowerLaw(const char *name, const char *title,
 +       RooAbsReal& _x, RooAbsReal& _x0, RooAbsReal& _c);
-+  RooPowerLaw(const RooPowerLaw& other, const char* name=0);
-+  virtual TObject* clone(const char* newname) const override { return new RooPowerLaw(*this,newname); }
-+  inline virtual ~RooPowerLaw() { }
++  RooPowerLaw(const RooPowerLaw& other, const char* name = nullptr);
++  TObject* clone(const char* newname) const override { return new RooPowerLaw(*this, newname); }
 +
-+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
-+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;
++  /// Get the x variable.
++  RooAbsReal const& getX() const { return x.arg(); }
++
++  /// Get the coefficient "c0".
++  RooAbsReal const& getExponent() const { return c.arg(); }
++
++  /// Get the coefficient "x0".
++  RooAbsReal const &getShift() const { return x0.arg(); }
++
++  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName = nullptr) const override;
++  double analyticalIntegral(Int_t code, const char* rangeName = nullptr) const override;
 +
 +protected:
 +  RooRealProxy x;
 +  RooRealProxy x0;
 +  RooRealProxy c;
 +
-+  Double_t evaluate() const override;
-+  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
++  double evaluate() const override;
++  void doEval(RooFit::EvalContext &) const override;
++  inline bool canComputeBatchWithCuda() const override { return true; }
 +
 +private:
-+  ClassDefOverride(RooPowerLaw,1) // PowerLaw PDF
++  ClassDefOverride(RooPowerLaw, 1) // PowerLaw PDF
 +};
 +
 +#endif
 diff --git a/roofit/roofit/src/RooPowerLaw.cxx b/roofit/roofit/src/RooPowerLaw.cxx
 new file mode 100644
-index 0000000000..a1b1a27094
+index 00000000000..590ee619f79
 --- /dev/null
 +++ b/roofit/roofit/src/RooPowerLaw.cxx
 @@ -0,0 +1,113 @@
@@ -140,9 +138,6 @@ index 0000000000..a1b1a27094
 + * Project: RooFit                                                           *
 + * Package: RooFitModels                                                     *
 + * @(#)root/roofit:$Id$
-+ * Authors:                                                                  *
-+ *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
-+ *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
 + *                                                                           *
 + * Copyright (c) 2000-2005, Regents of the University of California          *
 + *                          and Stanford University. All rights reserved.    *
@@ -174,34 +169,44 @@ index 0000000000..a1b1a27094
 +
 +#include <cmath>
 +
-+ClassImp(RooPowerLaw);
-+
 +////////////////////////////////////////////////////////////////////////////////
 +
 +RooPowerLaw::RooPowerLaw(const char *name, const char *title,
 +                RooAbsReal& _x, RooAbsReal& _x0, RooAbsReal& _c) :
 +  RooAbsPdf(name, title),
-+  x("x","Dependent",this,_x),
-+  x0("x0","Shift",this,_x0),
-+  c("c","Exponent",this,_c)
++  x("x", "Dependent", this, _x),
++  x0("x0", "Shift", this, _x0),
++  c("c", "Exponent", this, _c)
 +{
 +}
 +
 +////////////////////////////////////////////////////////////////////////////////
 +
 +RooPowerLaw::RooPowerLaw(const RooPowerLaw& other, const char* name) :
-+  RooAbsPdf(other, name), x("x",this,other.x), x0("x0",this,other.x0), c("c",this,other.c)
++  RooAbsPdf(other, name),
++  x("x", this, other.x),
++  x0("x0", this, other.x0),
++  c("c", this, other.c)
 +{
 +}
 +
 +////////////////////////////////////////////////////////////////////////////////
 +
-+Double_t RooPowerLaw::evaluate() const{
++double RooPowerLaw::evaluate() const
++{
 +  if (x > x0) {
 +    return std::pow(x - x0, c);
 +  } else {
 +    return 0.;
 +  }
++}
++
++////////////////////////////////////////////////////////////////////////////////
++/// Compute multiple values of Exponential distribution.
++void RooPowerLaw::doEval(RooFit::EvalContext &ctx) const
++{
++   auto computer = RooBatchCompute::Exponential;
++   RooBatchCompute::compute(ctx.config(this), computer, ctx.output(), {ctx.at(x), ctx.at(c)});
 +}
 +
 +////////////////////////////////////////////////////////////////////////////////
@@ -214,7 +219,7 @@ index 0000000000..a1b1a27094
 +
 +////////////////////////////////////////////////////////////////////////////////
 +
-+Double_t RooPowerLaw::analyticalIntegral(Int_t code, const char* rangeName) const
++double RooPowerLaw::analyticalIntegral(Int_t code, const char* rangeName) const
 +{
 +  R__ASSERT(code == 1);
 +
@@ -240,12 +245,5 @@ index 0000000000..a1b1a27094
 +
 +  auto k = constant + 1.;
 +
-+  return (std::pow(max - x0, k) - std::pow(min - x0, k))
-+      / k;
-+}
-+
-+////////////////////////////////////////////////////////////////////////////////
-+/// Compute multiple values of power law distribution.
-+RooSpan<double> RooPowerLaw::evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const {
-+  return RooBatchCompute::dispatch->computePowerLaw(this, evalData, x->getValues(evalData, normSet), x0->getValues(evalData, normSet), c->getValues(evalData, normSet));
++  return (std::pow(max - x0, k) - std::pow(min - x0, k)) / k;
 +}


### PR DESCRIPTION
Bumps root version from 6.24.02 to 6.32.16. The main improvement is the new vectorized CPU backend which greatly speeds up fit execution. In the custom PIDCalib fits in misid-unfold, **single-threaded fit execution in 6.32 is actually faster than multi-threaded fit execution in 6.24 (with `NumCPU(8)`) by almost a factor 10**. Hopefully this translates to the RDx fit as well (to be tested).

I initially tried to use the newest root version at the time (6.36), but starting with 6.34, root moves to a newer CMake  version which requires updating nixpkgs on our side.

This PR also patches [RooKeysPdf](https://root.cern.ch/doc/v632/classRooKeysPdf.html) to speed up the PDF construction with large MC samples (specially relevant above 1M events) and to allow linear transformations on the x axis.

TODO: Use latest patch in the 6.32 series before merging PR.